### PR TITLE
PRP-74 Create IAM roles to limit permissions to AWS users

### DIFF
--- a/infra/accounts/account/main.tf
+++ b/infra/accounts/account/main.tf
@@ -55,3 +55,4 @@ module "auth_github_actions" {
   github_actions_role_name = module.project_config.github_actions_role_name
   github_repository        = module.project_config.code_repository
 }
+# add iam module here?

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -25,6 +25,10 @@ module "app_config" {
   source = "../app-config"
 }
 
+module "iam" {
+  source = "../../modules/iam"
+}
+
 module "service" {
   source                = "../../modules/service"
   service_name          = local.service_name

--- a/infra/app/envs/prod/.terraform.lock.hcl
+++ b/infra/app/envs/prod/.terraform.lock.hcl
@@ -21,3 +21,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f6a26ce77f7db1d50ce311e32902fd001fb365e5e45e47a9a5cd59d734c89cb6",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.4.3"
+  hashes = [
+    "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+  ]
+}

--- a/infra/app/envs/prod/image_tag.tf
+++ b/infra/app/envs/prod/image_tag.tf
@@ -1,0 +1,42 @@
+# Make the "image_tag" variable optional so that "terraform plan"
+# and "terraform apply" work without any required variables.
+#
+# This works as follows:
+
+# 1. Accept an optional variable during a terraform plan/apply.
+variable "image_tag" {
+  description = "Docker tag of the API release to deploy."
+  type        = string
+  default     = null
+}
+
+#  2. Read the output used from the last terraform state using "terraform_remote_state".
+data "terraform_remote_state" "current_image_tag" {
+  # Don't do a lookup if image_tag is provided explicitly.
+  # This saves some time and also allows us to do a first deploy,
+  # where the tfstate file does not yet exist.
+  count   = var.image_tag == null ? 1 : 0
+  backend = "s3"
+
+  config = {
+    bucket = local.tfstate_bucket
+    key    = local.tfstate_key
+    region = local.region
+  }
+
+  defaults = {
+    image_tag = null
+  }
+}
+
+#  3. Prefer the given variable if provided, otherwise default to the value from last time.
+locals {
+  image_tag = (var.image_tag == null
+    ? data.terraform_remote_state.current_image_tag[0].outputs.image_tag
+  : var.image_tag)
+}
+
+#  4. Store the final value used as a terraform output for next time.
+output "image_tag" {
+  value = local.image_tag
+}

--- a/infra/app/envs/prod/main.tf
+++ b/infra/app/envs/prod/main.tf
@@ -2,6 +2,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
+  environment_name = "prod"
   # The prefix key/value pair is used for terraform workspaces, which is useful for projects with multiple infrastructure developers. 
   # Leave this as a static string if you are not using workspaces for this environment (recommended). Change it to terraform.workspace 
   # if you want to use workspaces in this environment.
@@ -13,6 +14,8 @@ locals {
     environment = "prod"
     description = "Application resources created in production environment"
   })
+  tfstate_bucket = "wic-prp-636249768232-us-west-1-tf-state"
+  tfstate_key    = "infra/wic-prp/environments/prod.tfstate"
 }
 
 terraform {
@@ -48,3 +51,8 @@ module "project_config" {
 }
 
 # Add application modules below
+module "app" {
+  source           = "../../env-template"
+  environment_name = local.environment_name
+  image_tag        = local.image_tag # this doesn't exist yet
+}

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -10,30 +10,13 @@ data "aws_iam_group" "team" {
   group_name = "wic-prp-eng"
 }
 
-# IAM Perms to create application-level infra
-resource "aws_iam_role" "wic-prp-eng" {
-  name               = "wic-prp-eng"
-  assume_role_policy = data.aws_iam_policy_document.wic-prp-eng.json
-}
-
-resource "aws_iam_role_policy" "wic-prp-eng" {
+resource "aws_iam_group_policy" "wic-prp-eng" {
   name   = "wic-prp-eng-policy"
-  role   = aws_iam_role.wic-prp-eng.arn
+  group  = data.aws_iam_group.team.group_name
   policy = data.aws_iam_policy_document.wic-prp-eng.json
 }
 
-data "aws_iam_policy_document" "wic-prp-eng-assume-role" {
-  statement {
-    sid     = "WICUsersAssumeRole"
-    actions = ["sts:AssumeRole", ]
-    principals {
-      type = "AWS"
-      identifiers = [
-        "*"
-      ]
-    }
-  }
-}
+# IAM Perms to create application-level infra
 
 data "aws_iam_policy_document" "wic-prp-eng" {
   statement {
@@ -95,7 +78,7 @@ data "aws_iam_policy_document" "wic-prp-eng" {
     sid       = "ECSServices"
     effect    = "Allow"
     actions   = ["ecs:DescribeServices"]
-    resources = ["arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:service/${ClusterName}/${ServiceName}"]
+    resources = ["arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:service/*/*"]
   }
   statement {
     sid    = "IAMServices"
@@ -112,10 +95,10 @@ data "aws_iam_policy_document" "wic-prp-eng" {
       "iam:ListRolePolicies",
       "iam:PutRolePolicy"
     ]
-    resources = [aws_iam_role.wic-prp-eng.arn]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/*"]
   }
   statement {
-    sid       = "KMSServices"
+    sid       = "KMSCreate"
     effect    = "Allow"
     actions   = ["kms:CreateAlias"]
     resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/*"]
@@ -143,6 +126,6 @@ data "aws_iam_policy_document" "wic-prp-eng" {
       "s3:PutBucketPolicy",
       "s3:PutBucketPublicAccessBlock"
     ]
-    resources = ["*"]
+    resources = ["arn:aws:s3:::*"]
   }
 }

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -1,0 +1,175 @@
+# IAM Perms to create application-level infra
+resource "aws_iam_role" "wic-prp-eng" {
+  name = "wic-prp-eng"
+  assume_role_policy = data.aws_iam_policy_document.wic-prp-eng.json
+}
+
+resource "aws_iam_role_policy" "wic-prp-eng" {
+  name = "wic-prp-eng-policy"
+  role = aws_iam_role.wic-prp-eng.arn
+  policy = data.aws_iam_policy_document.wic-prp-eng.json
+}
+
+data "aws_iam_policy_document" "wic-prp-eng" {
+  statement {
+    sid     = "WICUsersAssumeRole"
+    actions = ["sts:AssumeRole",]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "" # arn for the iam users here
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "wic-prp-eng"{
+    statement {
+      sid = "GenAcctAccess"
+      effect = "Allow"
+      actions = [
+        "cloudtrail:AddTags",
+        "cloudtrail:DescribeTrails",
+        "cloudtrail:ListTags",
+        "cloudtrail:ListTrails",
+        "cloudtrail:LookupEvents",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcs",
+        "ecr:DescribeRepositories",
+        "ecs:ListClusters",
+        "ecs:ListServices",
+        "iam:GetAccountPasswordPolicy",
+        "iam:GetAccountSummary",
+        "iam:GetServiceLastAccessedDetails",
+        "iam:ListAccountAliases",
+        "iam:ListGroups",
+        "iam:ListMFADevices",
+        "iam:ListOpenIDConnectProviders",
+        "iam:ListPolicies",
+        "iam:ListRoles",
+        "iam:ListSAMLProviders",
+        "iam:ListUsers",
+        "kms:CreateKey",
+        "kms:ListAliases",
+        "s3:GetAccountPublicAccessBlock",
+        "s3:ListAccessPoints",
+        "s3:ListAllMyBuckets",
+        "securityhub:DescribeHub",
+        "sts:GetCallerIdentity"
+      ]
+      resources = ["*"]
+    }
+    statement {
+      sid = "EC2Actions"
+      effect = "Allow"
+      actions = ["ec2:DescribeVpcAttribute",]
+      resources = [ "arn:aws:ec2:${Region}:${Account}:vpc/${VpcId}" ] #todo: fill this in
+    }
+    statement {
+      sid = "ECRActions"
+      effect = "Allow"
+      actions = [ "ecr:ListTagsForResource" ]
+      resources = [ "arn:aws:ecr:${Region}:${Account}:repository/${RepositoryName}" ]
+    }
+    statement {
+      sid = "ECSClusters"
+      effect = "Allow"
+      actions = [ "ecs:DescribeClusters" ]
+      resources = [ "arn:aws:ecs:${Region}:${Account}:cluster/${ClusterName}" ]
+    }
+    statement {
+      sid = "ECSServices"
+      effect = "Allow"
+      actions = [ "ecs:DescribeServices" ]
+      resources = [ "arn:aws:ecs:${Region}:${Account}:service/${ClusterName}/${ServiceName}" ]
+    }
+    statement {
+      sid = "IAMServices"
+      effect = "Allow"
+      actions = [
+        "iam:AttachRolePolicy",
+        "iam:CreateRole",
+        "iam:CreateServiceLinkedRole",
+        "iam:GenerateServiceLastAccessedDetails",
+        "iam:GetRole",
+        "iam:GetRolePolicy",
+        "iam:GetServiceLinkedRoleDeletionStatus",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListRolePolicies",
+        "iam:PutRolePolicy"
+      ]
+      resources = [ "arn:aws:iam::${Account}:role/${RoleNameWithPath}" ]
+    }
+    statement {
+      sid = "KMSServices"
+      effect = "Allow"
+      actions = ["kms:CreateAlias" ]
+      resources = [ "arn:aws:kms:${Region}:${Account}:alias/${Alias}" ]
+    }
+    statement {
+      sid = "KMSServices"
+      effect = "Allow"
+      actions = [
+        "kms:CreateAlias",
+        "kms:Decrypt",
+        "kms:PutKeyPolicy",
+        "kms:TagResource"
+       ]
+      resources = [ "arn:aws:kms:${Region}:${Account}:key/${KeyId}" ]
+    }
+    statement {
+      sid = "S3SServices"
+      effect = "Allow"
+      actions = [
+        "s3:CreateBucket",
+        "s3:GetBucketAcl",
+        "s3:GetBucketLocation",
+        "s3:GetBucketPolicyStatus",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:PutBucketPolicy",
+        "s3:PutBucketPublicAccessBlock"
+      ]
+      resources = [ "*" ]
+    }
+}
+
+# Misc Perms to be added to the infra role
+/* 
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": "cloudformation:DescribeStacks",
+			"Resource": "arn:aws:cloudformation:${Region}:${Account}:stack/${StackName}/${Id}"
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				"cloudtrail:CreateTrail",
+				"cloudtrail:GetEventSelectors",
+				"cloudtrail:GetInsightSelectors",
+				"cloudtrail:GetTrail",
+				"cloudtrail:GetTrailStatus",
+				"cloudtrail:PutEventSelectors",
+				"cloudtrail:PutInsightSelectors",
+				"cloudtrail:StartLogging"
+			],
+			"Resource": "arn:aws:cloudtrail:${Region}:${Account}:trail/${TrailName}"
+		},
+		{
+			"Effect": "Allow",
+			"Action": "iam:GenerateServiceLastAccessedDetails",
+			"Resource": "arn:aws:iam::${Account}:group/${GroupNameWithPath}"
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				"iam:CreatePolicy",
+				"iam:GenerateServiceLastAccessedDetails"
+			],
+			"Resource": "arn:aws:iam::${Account}:policy/${PolicyNameWithPath}"
+		},
+	]
+*/

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -6,13 +6,13 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 # References to current users
-data "aws_iam_group" "team" {
-  group_name = "wic-prp-eng"
+resource "aws_iam_group" "team" {
+  name = "wic-prp-eng"
 }
 
 resource "aws_iam_group_policy" "wic-prp-eng" {
   name   = "wic-prp-eng-policy"
-  group  = data.aws_iam_group.team.group_name
+  group  = aws_iam_group.team.name
   policy = data.aws_iam_policy_document.wic-prp-eng.json
 }
 

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -1,175 +1,148 @@
+# Data attributes
+data "aws_vpc" "default" {
+  default = true
+}
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# References to current users
+data "aws_iam_group" "team" {
+  group_name = "wic-prp-eng"
+}
+
 # IAM Perms to create application-level infra
 resource "aws_iam_role" "wic-prp-eng" {
-  name = "wic-prp-eng"
+  name               = "wic-prp-eng"
   assume_role_policy = data.aws_iam_policy_document.wic-prp-eng.json
 }
 
 resource "aws_iam_role_policy" "wic-prp-eng" {
-  name = "wic-prp-eng-policy"
-  role = aws_iam_role.wic-prp-eng.arn
+  name   = "wic-prp-eng-policy"
+  role   = aws_iam_role.wic-prp-eng.arn
   policy = data.aws_iam_policy_document.wic-prp-eng.json
 }
 
-data "aws_iam_policy_document" "wic-prp-eng" {
+data "aws_iam_policy_document" "wic-prp-eng-assume-role" {
   statement {
     sid     = "WICUsersAssumeRole"
-    actions = ["sts:AssumeRole",]
+    actions = ["sts:AssumeRole", ]
     principals {
       type = "AWS"
       identifiers = [
-        "" # arn for the iam users here
+        "*"
       ]
     }
   }
 }
 
-data "aws_iam_policy_document" "wic-prp-eng"{
-    statement {
-      sid = "GenAcctAccess"
-      effect = "Allow"
-      actions = [
-        "cloudtrail:AddTags",
-        "cloudtrail:DescribeTrails",
-        "cloudtrail:ListTags",
-        "cloudtrail:ListTrails",
-        "cloudtrail:LookupEvents",
-        "ec2:DescribeAccountAttributes",
-        "ec2:DescribeRouteTables",
-        "ec2:DescribeSubnets",
-        "ec2:DescribeVpcs",
-        "ecr:DescribeRepositories",
-        "ecs:ListClusters",
-        "ecs:ListServices",
-        "iam:GetAccountPasswordPolicy",
-        "iam:GetAccountSummary",
-        "iam:GetServiceLastAccessedDetails",
-        "iam:ListAccountAliases",
-        "iam:ListGroups",
-        "iam:ListMFADevices",
-        "iam:ListOpenIDConnectProviders",
-        "iam:ListPolicies",
-        "iam:ListRoles",
-        "iam:ListSAMLProviders",
-        "iam:ListUsers",
-        "kms:CreateKey",
-        "kms:ListAliases",
-        "s3:GetAccountPublicAccessBlock",
-        "s3:ListAccessPoints",
-        "s3:ListAllMyBuckets",
-        "securityhub:DescribeHub",
-        "sts:GetCallerIdentity"
-      ]
-      resources = ["*"]
-    }
-    statement {
-      sid = "EC2Actions"
-      effect = "Allow"
-      actions = ["ec2:DescribeVpcAttribute",]
-      resources = [ "arn:aws:ec2:${Region}:${Account}:vpc/${VpcId}" ] #todo: fill this in
-    }
-    statement {
-      sid = "ECRActions"
-      effect = "Allow"
-      actions = [ "ecr:ListTagsForResource" ]
-      resources = [ "arn:aws:ecr:${Region}:${Account}:repository/${RepositoryName}" ]
-    }
-    statement {
-      sid = "ECSClusters"
-      effect = "Allow"
-      actions = [ "ecs:DescribeClusters" ]
-      resources = [ "arn:aws:ecs:${Region}:${Account}:cluster/${ClusterName}" ]
-    }
-    statement {
-      sid = "ECSServices"
-      effect = "Allow"
-      actions = [ "ecs:DescribeServices" ]
-      resources = [ "arn:aws:ecs:${Region}:${Account}:service/${ClusterName}/${ServiceName}" ]
-    }
-    statement {
-      sid = "IAMServices"
-      effect = "Allow"
-      actions = [
-        "iam:AttachRolePolicy",
-        "iam:CreateRole",
-        "iam:CreateServiceLinkedRole",
-        "iam:GenerateServiceLastAccessedDetails",
-        "iam:GetRole",
-        "iam:GetRolePolicy",
-        "iam:GetServiceLinkedRoleDeletionStatus",
-        "iam:ListAttachedRolePolicies",
-        "iam:ListRolePolicies",
-        "iam:PutRolePolicy"
-      ]
-      resources = [ "arn:aws:iam::${Account}:role/${RoleNameWithPath}" ]
-    }
-    statement {
-      sid = "KMSServices"
-      effect = "Allow"
-      actions = ["kms:CreateAlias" ]
-      resources = [ "arn:aws:kms:${Region}:${Account}:alias/${Alias}" ]
-    }
-    statement {
-      sid = "KMSServices"
-      effect = "Allow"
-      actions = [
-        "kms:CreateAlias",
-        "kms:Decrypt",
-        "kms:PutKeyPolicy",
-        "kms:TagResource"
-       ]
-      resources = [ "arn:aws:kms:${Region}:${Account}:key/${KeyId}" ]
-    }
-    statement {
-      sid = "S3SServices"
-      effect = "Allow"
-      actions = [
-        "s3:CreateBucket",
-        "s3:GetBucketAcl",
-        "s3:GetBucketLocation",
-        "s3:GetBucketPolicyStatus",
-        "s3:GetBucketPublicAccessBlock",
-        "s3:PutBucketPolicy",
-        "s3:PutBucketPublicAccessBlock"
-      ]
-      resources = [ "*" ]
-    }
+data "aws_iam_policy_document" "wic-prp-eng" {
+  statement {
+    sid    = "GenAcctAccess"
+    effect = "Allow"
+    actions = [
+      "cloudtrail:AddTags",
+      "cloudtrail:DescribeTrails",
+      "cloudtrail:ListTags",
+      "cloudtrail:ListTrails",
+      "cloudtrail:LookupEvents",
+      "ec2:DescribeAccountAttributes",
+      "ec2:DescribeRouteTables",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeVpcs",
+      "ecr:DescribeRepositories",
+      "ecs:ListClusters",
+      "ecs:ListServices",
+      "iam:GetAccountPasswordPolicy",
+      "iam:GetAccountSummary",
+      "iam:GetServiceLastAccessedDetails",
+      "iam:ListAccountAliases",
+      "iam:ListGroups",
+      "iam:ListMFADevices",
+      "iam:ListOpenIDConnectProviders",
+      "iam:ListPolicies",
+      "iam:ListRoles",
+      "iam:ListSAMLProviders",
+      "iam:ListUsers",
+      "kms:CreateKey",
+      "kms:ListAliases",
+      "s3:GetAccountPublicAccessBlock",
+      "s3:ListAccessPoints",
+      "s3:ListAllMyBuckets",
+      "securityhub:DescribeHub",
+      "sts:GetCallerIdentity"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "EC2Actions"
+    effect    = "Allow"
+    actions   = ["ec2:DescribeVpcAttribute", ]
+    resources = [data.aws_vpc.default.arn]
+  }
+  statement {
+    sid       = "ECRActions"
+    effect    = "Allow"
+    actions   = ["ecr:ListTagsForResource"]
+    resources = ["arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*"]
+  }
+  statement {
+    sid       = "ECSClusters"
+    effect    = "Allow"
+    actions   = ["ecs:DescribeClusters"]
+    resources = ["arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/*"]
+  }
+  statement {
+    sid       = "ECSServices"
+    effect    = "Allow"
+    actions   = ["ecs:DescribeServices"]
+    resources = ["arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:service/${ClusterName}/${ServiceName}"]
+  }
+  statement {
+    sid    = "IAMServices"
+    effect = "Allow"
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:CreateRole",
+      "iam:CreateServiceLinkedRole",
+      "iam:GenerateServiceLastAccessedDetails",
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:GetServiceLinkedRoleDeletionStatus",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListRolePolicies",
+      "iam:PutRolePolicy"
+    ]
+    resources = [aws_iam_role.wic-prp-eng.arn]
+  }
+  statement {
+    sid       = "KMSServices"
+    effect    = "Allow"
+    actions   = ["kms:CreateAlias"]
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/*"]
+  }
+  statement {
+    sid    = "KMSServices"
+    effect = "Allow"
+    actions = [
+      "kms:CreateAlias",
+      "kms:Decrypt",
+      "kms:PutKeyPolicy",
+      "kms:TagResource"
+    ]
+    resources = ["arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*"]
+  }
+  statement {
+    sid    = "S3SServices"
+    effect = "Allow"
+    actions = [
+      "s3:CreateBucket",
+      "s3:GetBucketAcl",
+      "s3:GetBucketLocation",
+      "s3:GetBucketPolicyStatus",
+      "s3:GetBucketPublicAccessBlock",
+      "s3:PutBucketPolicy",
+      "s3:PutBucketPublicAccessBlock"
+    ]
+    resources = ["*"]
+  }
 }
-
-# Misc Perms to be added to the infra role
-/* 
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Effect": "Allow",
-			"Action": "cloudformation:DescribeStacks",
-			"Resource": "arn:aws:cloudformation:${Region}:${Account}:stack/${StackName}/${Id}"
-		},
-		{
-			"Effect": "Allow",
-			"Action": [
-				"cloudtrail:CreateTrail",
-				"cloudtrail:GetEventSelectors",
-				"cloudtrail:GetInsightSelectors",
-				"cloudtrail:GetTrail",
-				"cloudtrail:GetTrailStatus",
-				"cloudtrail:PutEventSelectors",
-				"cloudtrail:PutInsightSelectors",
-				"cloudtrail:StartLogging"
-			],
-			"Resource": "arn:aws:cloudtrail:${Region}:${Account}:trail/${TrailName}"
-		},
-		{
-			"Effect": "Allow",
-			"Action": "iam:GenerateServiceLastAccessedDetails",
-			"Resource": "arn:aws:iam::${Account}:group/${GroupNameWithPath}"
-		},
-		{
-			"Effect": "Allow",
-			"Action": [
-				"iam:CreatePolicy",
-				"iam:GenerateServiceLastAccessedDetails"
-			],
-			"Resource": "arn:aws:iam::${Account}:policy/${PolicyNameWithPath}"
-		},
-	]
-*/

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -458,7 +458,7 @@ resource "aws_rds_cluster_parameter_group" "rds_query_logging" {
 
   parameter {
     name  = "log_statement"
-    value = "all"
+    value = "all" # ddl for template; none for wic
   }
 
   parameter {


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-74

## Changes
* add policy document with the IAM roles needed for engineers

## Context for reviewers
> We need to limit access to comply with best practices of “least privilege” for our engineering staff and for automation tools.

> Privileges are managed through one higher-privileged account
> 
> wic-prp-eng: This will be the standard IAM role for engineers on the team. This role should give access to appropriate resources such as: S3, ECS,ECR,RDS/Aurora, IAM etc
> 
> IAM privileges for this account are limited to changes to the wic-prp-infra role
> 
> wic-prp-infra: This is a dedicated role for infrastructure access. This role will give access to resources such as: Route53, certificate manager, VPC,etc
> 
> wic-prp-privileged: This role is used to modify privileges for the wic-prp-eng role, and to grant new users access to AWS (creating accounts and assigning those accounts to either wic-prp-eng or wic-prp-infra as appropriate)

## Testing
1. Log in to the AWS console and confirm that you have the proper permissions associated with the `wic-mt-eng` and the `wic-prp-privileged` users
