### PR TITLE
[PRP 205] Add IAM policy so users can manage MFA

### DIFF
--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -5,20 +5,26 @@ data "aws_vpc" "default" {
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-# References to current users
-resource "aws_iam_group" "team" {
+# Create a user group for engineers managing environments
+resource "aws_iam_group" "wic_prp_eng" {
   name = "wic-prp-eng"
 }
 
-resource "aws_iam_group_policy" "wic-prp-eng" {
-  name   = "wic-prp-eng-policy"
-  group  = aws_iam_group.team.name
-  policy = data.aws_iam_policy_document.wic-prp-eng.json
+# Create a policy with all the permissions necessary to create and destroy a WIC PPR environment
+resource "aws_iam_policy" "manage_wic_prp_env" {
+  name = "manage-wic-prp-env"
+  description = "A policy that supports all permissions necessary to create and destroy a WIC PRP environment"
+  policy = data.aws_iam_policy_document.manage_wic_prp_env.json
 }
 
-# IAM Perms to create application-level infra
+# Attach the manage_wic_prp_env policy to the group
+resource "aws_iam_group_policy_attachment" "manage_wic_prp_env" {
+  group  = aws_iam_group.wic_prp_eng.name
+  policy_arn = aws_iam_policy.manage_wic_prp_env.arn
+}
 
-data "aws_iam_policy_document" "wic-prp-eng" {
+# Define the policy for managing PRP environments
+data "aws_iam_policy_document" "manage_wic_prp_env" {
   statement {
     sid    = "General"
     effect = "Allow"

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -12,14 +12,14 @@ resource "aws_iam_group" "wic_prp_eng" {
 
 # Create a policy with all the permissions necessary to create and destroy a WIC PPR environment
 resource "aws_iam_policy" "manage_wic_prp_env" {
-  name = "manage-wic-prp-env"
+  name        = "manage-wic-prp-env"
   description = "A policy that supports all permissions necessary to create and destroy a WIC PRP environment"
-  policy = data.aws_iam_policy_document.manage_wic_prp_env.json
+  policy      = data.aws_iam_policy_document.manage_wic_prp_env.json
 }
 
 # Attach the manage_wic_prp_env policy to the group
 resource "aws_iam_group_policy_attachment" "manage_wic_prp_env" {
-  group  = aws_iam_group.wic_prp_eng.name
+  group      = aws_iam_group.wic_prp_eng.name
   policy_arn = aws_iam_policy.manage_wic_prp_env.arn
 }
 
@@ -262,20 +262,20 @@ data "aws_iam_policy_document" "manage_wic_prp_env" {
 
 # Attach the managed AWS IAMUserChangePassword policy to the wic-prp-eng group
 resource "aws_iam_group_policy_attachment" "change_own_password" {
-  group  = aws_iam_group.wic_prp_eng.name
+  group      = aws_iam_group.wic_prp_eng.name
   policy_arn = "arn:aws:iam::aws:policy/IAMUserChangePassword"
 }
 
 # Create a policy to allow users in the wic-prp-eng group to manage MFA
 resource "aws_iam_policy" "manage_mfa" {
-  name = "manage-mfa"
+  name        = "manage-mfa"
   description = "A policy to manage and enforce MFA"
-  policy = data.aws_iam_policy_document.manage_mfa.json
+  policy      = data.aws_iam_policy_document.manage_mfa.json
 }
 
 # Attach the manage-mfa policy to the wic-prp-eng group
 resource "aws_iam_group_policy_attachment" "manage_mfa" {
-  group  = aws_iam_group.wic_prp_eng.name
+  group      = aws_iam_group.wic_prp_eng.name
   policy_arn = aws_iam_policy.manage_mfa.arn
 }
 


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-205

## Changes
> What was added, updated, or removed in this PR.

- Add a policy to allow users in the `wic-prp-eng` user group to manage MFA
- Change from an inline policy attachment to a customer managed policy
- Rename policies to explain their function
- Add AWS managed policy for changing own password

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

I ran into issues trying to enable MFA for users in the `wic-prp-eng` user group, so this PR allows them to add/manage their own MFA devices.

In addition, I had been running into max character limit issues for the IAM policy and it turns out that [inline policies have a lower max character limit](https://aws.amazon.com/premiumsupport/knowledge-center/iam-increase-policy-size/). In addition, it's best practice to use customer managed policies instead of inline policies, so I switched our policy accordingly.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

1. Auth as a user in the `wic-prp-eng` group
2. Attempt to [create an MFA device]([AWS](https://us-east-1.console.aws.amazon.com/iamv2/home#/security_credentials?section=IAM_credentials)
3. It should allow you to