### PR TITLE
[PRP-222] Creating Document schema and relations

### DIFF
--- a/participant/prisma/migrations/20230326200013_create_documents_table/migration.sql
+++ b/participant/prisma/migrations/20230326200013_create_documents_table/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "documents" (
+    "document_id" UUID NOT NULL,
+    "submission_id" UUID NOT NULL,
+    "s3_path" TEXT NOT NULL,
+    "detected_filetype" TEXT,
+    "virus_scan_status" TEXT,
+    "detected_filesize_bytes" INTEGER,
+    "original_filename" TEXT NOT NULL,
+    "sha256_hash" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "documents_pkey" PRIMARY KEY ("document_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "documents" ADD CONSTRAINT "documents_submission_id_fkey" FOREIGN KEY ("submission_id") REFERENCES "submissions"("submission_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/participant/prisma/schema.prisma
+++ b/participant/prisma/schema.prisma
@@ -15,6 +15,7 @@ model Submission {
   updatedAt       DateTime         @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   submitted       Boolean          @default(false)
   submissionForms SubmissionForm[]
+  documents       Document[]
 
   @@map("submissions")
 }
@@ -40,4 +41,20 @@ model LocalAgency {
   submissions   Submission[]
 
   @@map("local_agencies")
+}
+
+model Document {
+  documentId            String     @id @default(uuid()) @map("document_id") @db.Uuid
+  submissionId          String     @map("submission_id") @db.Uuid
+  s3Path                String     @map("s3_path")
+  detectedFiletype      String?    @map("detected_filetype")
+  virusScanStatus       String?    @map("virus_scan_status")
+  detectedFilesizeBytes Int?       @map("detected_filesize_bytes")
+  originalFilename      String     @map("original_filename")
+  sha256Hash            String?    @map("sha256_hash")
+  createdAt             DateTime   @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt             DateTime   @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+  submission            Submission @relation(fields: [submissionId], references: [submissionId])
+
+  @@map("documents")
 }


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-222

## Changes
* Document table created
* Relation to Submission added


## Context for reviewers

Note that _additional_ fields were made optional in the migration to remove potential implementation restrictions for the time being

Optional Fields:
* detectedFiletype
* virusScanStatus
* detectedFilesizeBytes
* sha256Hash

![Schema Diagram](https://user-images.githubusercontent.com/723391/227801639-189bc73c-63fe-4846-b3d1-c48fe8879457.png)


## Testing
> npx prisma migrate dev
> psql -h127.0.0.1 -Upostgres (and enter your password)
> postgres=# \d+ documents;