### PR TITLE
[PRP-218] Initial routing, ButtonLink component

### DIFF
--- a/participant/app/components/ButtonLink.tsx
+++ b/participant/app/components/ButtonLink.tsx
@@ -1,0 +1,22 @@
+import type { ReactElement } from "react";
+import { Link as RemixLink } from "@remix-run/react";
+import type { LinkProps as RemixLinkProps } from "@remix-run/react";
+import { Link as USWDSLink } from "@trussworks/react-uswds";
+import type { CustomLinkProps as USWDSLinkProps } from "@trussworks/react-uswds/lib/components/Link/Link";
+
+export type ButtonLinkProps = Omit<USWDSLinkProps<RemixLinkProps>, "asCustom">;
+
+export const ButtonLink = (props: ButtonLinkProps): ReactElement => {
+  const { className = "", variant = "unstyled", to, children, ...rest } = props;
+  return (
+    <USWDSLink
+      asCustom={RemixLink}
+      className={`usa-button ${className}`}
+      variant={variant}
+      to={to}
+      {...rest}
+    >
+      {children}
+    </USWDSLink>
+  );
+};

--- a/participant/app/components/ButtonLink.tsx
+++ b/participant/app/components/ButtonLink.tsx
@@ -11,7 +11,7 @@ export const ButtonLink = (props: ButtonLinkProps): ReactElement => {
   return (
     <USWDSLink
       asCustom={RemixLink}
-      className={`usa-button ${className}`}
+      className={`usa-button ${className}`.trim()}
       variant={variant}
       to={to}
       {...rest}

--- a/participant/app/routes/$localAgency/recertify/about.tsx
+++ b/participant/app/routes/$localAgency/recertify/about.tsx
@@ -1,10 +1,10 @@
 import { Alert } from "@trussworks/react-uswds";
-import { Button } from "@trussworks/react-uswds";
 import { ProcessList } from "@trussworks/react-uswds";
 import { ProcessListHeading } from "@trussworks/react-uswds";
 import { ProcessListItem } from "@trussworks/react-uswds";
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
+import { ButtonLink } from "app/components/ButtonLink";
 
 export default function Index() {
   const { t } = useTranslation();
@@ -28,9 +28,9 @@ export default function Index() {
       <Alert type="warning" headingLevel="h3" slim noIcon>
         {t("About.note")}
       </Alert>
-      <Button className="display-block margin-top-6" type="button">
+      <ButtonLink to="../name" relative="path" className="margin-top-6">
         {t("About.button")}
-      </Button>
+      </ButtonLink>
     </div>
   );
 }

--- a/participant/app/routes/$localAgency/recertify/index.tsx
+++ b/participant/app/routes/$localAgency/recertify/index.tsx
@@ -1,7 +1,7 @@
-import { Button } from "@trussworks/react-uswds";
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { List } from "~/components/List";
+import { ButtonLink } from "app/components/ButtonLink";
+import { List } from "app/components/List";
 
 export default function Index() {
   const { t } = useTranslation();
@@ -33,9 +33,9 @@ export default function Index() {
           <Trans i18nKey="Index.time" />
         </p>
       </div>
-      <Button className="display-block margin-top-6" type="button">
+      <ButtonLink to="about" className="margin-top-6">
         {t("Index.button")}
-      </Button>
+      </ButtonLink>
     </div>
   );
 }

--- a/participant/app/routes/$localAgency/recertify/name.tsx
+++ b/participant/app/routes/$localAgency/recertify/name.tsx
@@ -3,7 +3,11 @@ import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { NameInput } from "~/components/NameInput";
 import type { NameInputProps } from "~/components/NameInput";
-import { Form } from "@remix-run/react";
+import { ValidatedForm } from "remix-validated-form";
+import { representativeNameSchema } from "app/utils/validation";
+import { withZod } from "@remix-validated-form/with-zod";
+
+const representativeNameValidator = withZod(representativeNameSchema);
 
 export default function Index() {
   const { t } = useTranslation();
@@ -25,7 +29,7 @@ export default function Index() {
       <div>
         <Trans i18nKey="Name.body" />
       </div>
-      <Form>
+      <ValidatedForm validator={representativeNameValidator}>
         <NameInput {...nameInputProps} />
         <Button
           className="display-block margin-top-6"
@@ -34,7 +38,7 @@ export default function Index() {
         >
           {t("Name.button")}
         </Button>
-      </Form>
+      </ValidatedForm>
     </div>
   );
 }

--- a/participant/app/utils/validation.ts
+++ b/participant/app/utils/validation.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { zfd } from "zod-form-data";
+
+const nameSchemaFactory = (idPrefix: string) => {
+  /* eslint-disable-rule @typescript-eslint/no-unused-vars
+     I do not understand why eslint thinks we're not using these vars
+  */
+  const firstNameKey = `${idPrefix}-firstName`;
+  const lastNameKey = `${idPrefix}-lastName`;
+  const preferredNameKey = `${idPrefix}-preferredName`;
+  return zfd.formData({
+    [firstNameKey]: zfd.text(
+      z.string().min(1, { message: "First name is required" })
+    ),
+    [lastNameKey]: zfd.text(
+      z.string().min(1, { message: "Last name is required" })
+    ),
+    [preferredNameKey]: zfd.text(z.string().optional()),
+  });
+};
+
+export const representativeNameSchema = nameSchemaFactory("representative");

--- a/participant/e2e/routes/about.spec.ts
+++ b/participant/e2e/routes/about.spec.ts
@@ -23,3 +23,15 @@ test("the about page sets no cookies", async ({ page }) => {
   const cookies = await page.context().cookies();
   expect(cookies).toHaveLength(0);
 });
+
+test("clicking the continue button should take you to /name", async ({
+  page,
+}) => {
+  await page.goto("/gallatin/recertify/about");
+
+  // Click the get started link (button).
+  await page.getByRole("link", { name: "Continue" }).click();
+
+  // Expects the URL to contain /name.
+  await expect(page).toHaveURL(/name/);
+});

--- a/participant/e2e/routes/index.spec.ts
+++ b/participant/e2e/routes/index.spec.ts
@@ -23,3 +23,15 @@ test("the index page sets no cookies", async ({ page }) => {
   const cookies = await page.context().cookies();
   expect(cookies).toHaveLength(0);
 });
+
+test("clicking the get started link should take you to about", async ({
+  page,
+}) => {
+  await page.goto("/gallatin/recertify");
+
+  // Click the get started link (button).
+  await page.getByRole("link", { name: "Get started" }).click();
+
+  // Expects the URL to contain /about.
+  await expect(page).toHaveURL(/about/);
+});

--- a/participant/stories/components/ButtonLink.stories.tsx
+++ b/participant/stories/components/ButtonLink.stories.tsx
@@ -1,0 +1,25 @@
+import { ButtonLink } from "app/components/ButtonLink";
+import type { ButtonLinkProps } from "app/components/ButtonLink";
+
+export default {
+  component: ButtonLink,
+  title: "Components/ButtonLink",
+};
+
+const defaultProps: ButtonLinkProps = {
+  to: "#",
+  children: "Button",
+};
+
+const ButtonLinkTemplate = {
+  render: (props: ButtonLinkProps) => {
+    return <ButtonLink {...props} />;
+  },
+};
+
+export const Default = {
+  ...ButtonLinkTemplate,
+  args: {
+    ...defaultProps,
+  },
+};

--- a/participant/tests/components/ButtonLink.test.tsx
+++ b/participant/tests/components/ButtonLink.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from "@testing-library/react";
+import { renderWithRouter } from "tests/helpers/setup";
+import { ButtonLink } from "app/components/ButtonLink";
+
+it("should render a button using an internal to target", () => {
+  const { container } = renderWithRouter(
+    <ButtonLink to="bogus">Button Text</ButtonLink>
+  );
+  expect(container).toMatchSnapshot();
+  expect(
+    screen.getByRole("link", { name: "Button Text" }).getAttribute("href")
+  ).toBe("/bogus");
+});
+
+it("should render a button using an external to target", () => {
+  const { container } = renderWithRouter(
+    <ButtonLink to="https://google.com">Button Text</ButtonLink>
+  );
+  expect(container).toMatchSnapshot();
+  expect(
+    screen.getByRole("link", { name: "Button Text" }).getAttribute("href")
+  ).toBe("https://google.com");
+});

--- a/participant/tests/components/__snapshots__/ButtonLink.test.tsx.snap
+++ b/participant/tests/components/__snapshots__/ButtonLink.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`should render a button using an external to target 1`] = `
 <div>
   <a
-    class="usa-button "
+    class="usa-button"
     href="https://google.com"
   >
     Button Text
@@ -14,7 +14,7 @@ exports[`should render a button using an external to target 1`] = `
 exports[`should render a button using an internal to target 1`] = `
 <div>
   <a
-    class="usa-button "
+    class="usa-button"
     href="/bogus"
   >
     Button Text

--- a/participant/tests/components/__snapshots__/ButtonLink.test.tsx.snap
+++ b/participant/tests/components/__snapshots__/ButtonLink.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a button using an external to target 1`] = `
+<div>
+  <a
+    class="usa-button "
+    href="https://google.com"
+  >
+    Button Text
+  </a>
+</div>
+`;
+
+exports[`should render a button using an internal to target 1`] = `
+<div>
+  <a
+    class="usa-button "
+    href="/bogus"
+  >
+    Button Text
+  </a>
+</div>
+`;


### PR DESCRIPTION
…as desired, updated tests, e2e, storybook

## Ticket

https://wicmtdp.atlassian.net/browse/PRP-218

## Changes
* Created new (better?) `<ButtonLink>` component that uses both USWDS `<Link>` and Remix `<Link>`
* Created Storybook story for `<ButtonLink>`
* Created Jest tests for `<ButtonLink>`
* Added routing behavior for `about.tsx`, `index.tsx` pages
* Updated e2e tests to validate navigation
* Ensured `name.tsx` page renders by changing `<Form>` to `<ValidatedForm>` and adding validation schema for the Representative Name


## Context for reviewers
* Clicking on the call to action button on `localAgency/recertify/` routes the user to `localAgency/recertify/about`
* Clicking on the call to action button on `localAgency/recertify/about` routes the user to `localAgency/recertify/name`


## Testing
![demo-prp-218](https://user-images.githubusercontent.com/723391/227806201-b7b75012-522e-46e2-b4b5-7554cac6eca6.gif)


