### PR TITLE
[PRP-259] Fix participant deploy issue

### DIFF
--- a/participant/Dockerfile
+++ b/participant/Dockerfile
@@ -1,8 +1,11 @@
 # -------- Image: base -------- #
 # Base node image with package updates and dependencies
-FROM node:18-slim as base
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
+# Use alpine to force using openssl@3 for prisma segfault issue
+# See https://github.com/prisma/prisma/issues/10649#issuecomment-1430379940
+FROM node:18-alpine as base
+RUN apk update \
+  && apk upgrade \
+  && apk add --no-cache \
     # Install curl for healthcheck
     curl \
     # Install openssl for Prisma

--- a/participant/bin/prod-start.sh
+++ b/participant/bin/prod-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 npx prisma migrate deploy
 npx prisma db seed
 npx remix-serve build/


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-259

## Changes
> What was added, updated, or removed in this PR.

- Change participant image to use alpine rather than debian
- Change participant command script to use `/bin/sh` instead of `/bin/bash` for alpine

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

The participant ECS task was dying with a segfault:

```
npm notice
npm notice New minor version of npm available! 9.5.0 -> 9.6.4
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.6.4>
npm notice Run `npm install -g npm@9.6.4` to update!
npm notice
Prisma schema loaded from prisma/schema.prisma
Datasource "db": PostgreSQL database <redacted>
3 migrations found in prisma/migrations
No pending migrations to apply.
Running seed command `ts-node  --require tsconfig-paths/register --compiler-options {     "module": "CommonJS" } prisma/seed.ts` ...
An error occurred while running the seed command:
Error: Command was killed with SIGSEGV (Segmentation fault): ts-node --require tsconfig-paths/register --compiler-options {     "module": "CommonJS" } prisma/seed.ts
Remix App Server started at http://localhost:3000 <redacted>
Segmentation fault
```

After trying a number of different approaches, I was able to identify that it was the same issue as listed in https://github.com/prisma/prisma/issues/10649. Specfically, following [this comment's](https://github.com/prisma/prisma/issues/10649#issuecomment-1430379940) insights, I was able to identify that we were indeed using openssl 1.x along with node 18.x.

Running `npx prisma version` in the ECS container returned:

```
prisma                  : 4.11.0
@prisma/client          : 4.11.0
Current platform        : debian-openssl-1.1.x
Query Engine (Node-API) : libquery-engine 8fde8fef4033376662cad983758335009d522acb (at node_modules/@prisma/engines/libquery_engine-debian-openssl-1.1.x.so.node)
Migration Engine        : migration-engine-cli 8fde8fef4033376662cad983758335009d522acb (at node_modules/@prisma/engines/migration-engine-debian-openssl-1.1.x)
Format Wasm             : @prisma/prisma-fmt-wasm 4.11.0-57.8fde8fef4033376662cad983758335009d522acb
Default Engines Hash    : 8fde8fef4033376662cad983758335009d522acb
Studio                  : 0.483.0
```
And running `apt list openssl` returned:

```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
Listing...
openssl/stable-security,now 1.1.1n-0+deb11u4 amd64 [installed]
openssl/stable 1.1.1n-0+deb11u3 amd64
```

Switching over to alpine returns the correct openssl 3.x version needed:

```
prisma                  : 4.11.0
@prisma/client          : 4.11.0
Current platform        : linux-musl-openssl-3.0.x
Query Engine (Node-API) : libquery-engine 8fde8fef4033376662cad983758335009d522acb (at node_modules/@prisma/engines/libquery_engine-linux-musl-openssl-3.0.x.so.node)
Migration Engine        : migration-engine-cli 8fde8fef4033376662cad983758335009d522acb (at node_modules/@prisma/engines/migration-engine-linux-musl-openssl-3.0.x)
Format Wasm             : @prisma/prisma-fmt-wasm 4.11.0-57.8fde8fef4033376662cad983758335009d522acb
Default Engines Hash    : 8fde8fef4033376662cad983758335009d522acb
Studio                  : 0.483.0
npm notice
npm notice New minor version of npm available! 9.5.0 -> 9.6.4
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.6.4>
npm notice Run `npm install -g npm@9.6.4` to update!
npm notice
libcrypto3-3.0.8-r3 x86_64 {openssl} (Apache-2.0) [installed]
openssl-3.0.8-r3 x86_64 {openssl} (Apache-2.0) [installed]
libssl3-3.0.8-r3 x86_64 {openssl} (Apache-2.0) [installed]
Prisma schema loaded from prisma/schema.prisma
Datasource "db": PostgreSQL database <redacted>
3 migrations found in prisma/migrations
No pending migrations to apply.
Running seed command `ts-node  --require tsconfig-paths/register --compiler-options {"module":"CommonJS"} prisma/seed.ts` ...
Database has been seeded. 🌱
🌱  The seed command has been executed.
Remix App Server started at http://localhost:3000 <redacted>
Redirecting to baseUrl /gallatin/recertify
HEAD / 302 - - 949.086 ms
HEAD /gallatin/recertify 200 - - 157.063 ms
GET /healthcheck 200 - - 1306.803 ms

```

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

This fix has been deployed to dev and staging.
