### PR TITLE
[PRP-268] Correctly allow Github and Terraform to manage ECS task definitions

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -113,12 +113,17 @@ resource "aws_lb_target_group" "alb_target_group" {
 #######################
 
 resource "aws_ecs_service" "app" {
+  # checkov:skip=CKV_AWS_333: This is literally a new check; more research needed
+
   name                   = var.service_name
   cluster                = var.service_cluster_arn
   launch_type            = "FARGATE"
   task_definition        = aws_ecs_task_definition.app.arn
   desired_count          = var.desired_instance_count
-  platform_version       = "1.4.0"
+  # Fargate platform_version must be at least 1.4.0 for Fargate + EFS to work
+  # LATEST is currently 1.4.0
+  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-linux-fargate.html
+  platform_version       = "LATEST"
   enable_execute_command = var.enable_exec ? true : null
 
   # Allow changes to the desired_count without differences in terraform plan.

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -1,3 +1,12 @@
+# NOTE: By default, this module ignores changes to the ECS service task definition and ignores changes to the ECS task
+# definition container definitions so that Github Actions can manage deploys by creating new task definition versions.
+# Sometimes we need to deploy updates to container definitions and update the ECS service. Normally, we would control
+# this behavior with a variable. However, terraform currently doesn't support expression evaluation in the `lifecycle`
+# block. See https://github.com/hashicorp/terraform/issues/3116
+#
+# To change this, TEMPORARILY comment out the lines following:
+#  `IGNORE_GITHUB_CHANGES - comment out next line to deploy changes via terraform`
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
@@ -131,15 +140,7 @@ resource "aws_ecs_service" "app" {
   lifecycle {
     ignore_changes = [
       desired_count,
-      # NOTE: By default, this module ignores changes to the ECS service task definition and ignores changes to the ECS task
-      # definition container definitions so that Github Actions can manage deploys by creating new task definition versions.
-      # Sometimes we need to deploy updates to container definitions and update the ECS service. Normally, we would control
-      # this behavior with a variable. However, terraform currently doesn't support expression evaluation in the `lifecycle`
-      # block. See https://github.com/hashicorp/terraform/issues/3116
-      #
-      # To deploy general updates to the task definition, **TEMPORARILY** uncomment the next line.
-      # To deploy general updates to the task definition and/or updates to the task's container definition,
-      #   **TEMPORARILY** uncomment the next line AND the `ignore_changes` line in the aws_ecs_task_definition below.
+      # IGNORE_GITHUB_CHANGES - comment out next line to deploy changes via terraform
       task_definition,
     ]
   }
@@ -253,18 +254,7 @@ resource "aws_ecs_task_definition" "app" {
 
   lifecycle {
     ignore_changes = [
-      # NOTE: By default, this module ignores changes to the ECS service task definition and ignores changes to the ECS task
-      # definition container definitions so that Github Actions can manage deploys by creating new task definition versions.
-      # Sometimes we need to deploy updates to container definitions and update the ECS service. Normally, we would control
-      # this behavior with a variable. However, terraform currently doesn't support expression evaluation in the `lifecycle`
-      # block. See https://github.com/hashicorp/terraform/issues/3116
-      #
-      # If you uncomment the container_definitions line, pass in -var="image_tag=<correct_image_tag>". Otherwise, the task
-      # will deploy with a non-existent image tag "latest".
-      #
-      # To deploy general updates to the container definition, **TEMPORARILY** uncomment
-      # - the next line
-      # - AND the `ignore_changes` line in the aws_ecs_service above
+      # IGNORE_GITHUB_CHANGES - comment out next line to deploy changes via terraform
       container_definitions,
     ]
   }

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -115,14 +115,14 @@ resource "aws_lb_target_group" "alb_target_group" {
 resource "aws_ecs_service" "app" {
   # checkov:skip=CKV_AWS_333: This is literally a new check; more research needed
 
+  # Fargate platform_version must be at least 1.4.0 for Fargate + EFS to work
+  # LATEST is currently 1.4.0
+  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-linux-fargate.html
   name                   = var.service_name
   cluster                = var.service_cluster_arn
   launch_type            = "FARGATE"
   task_definition        = aws_ecs_task_definition.app.arn
   desired_count          = var.desired_instance_count
-  # Fargate platform_version must be at least 1.4.0 for Fargate + EFS to work
-  # LATEST is currently 1.4.0
-  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform-linux-fargate.html
   platform_version       = "LATEST"
   enable_execute_command = var.enable_exec ? true : null
 

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -139,3 +139,9 @@ variable "enable_exec" {
   description = "Enable exec access to ECS task"
   default     = false
 }
+
+variable "redeploy_service" {
+  type = bool
+  description = "By default, this module ignores changes to the ECS service task definition and ignores changes to the ECS task definition container definitions. Set this variable to true to OVERRIDE these ignores and actively update the container definitions and redeploy the service"
+  default = false
+}

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -139,9 +139,3 @@ variable "enable_exec" {
   description = "Enable exec access to ECS task"
   default     = false
 }
-
-variable "redeploy_service" {
-  type = bool
-  description = "By default, this module ignores changes to the ECS service task definition and ignores changes to the ECS task definition container definitions. Set this variable to true to OVERRIDE these ignores and actively update the container definitions and redeploy the service"
-  default = false
-}


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-268

## Changes
> What was added, updated, or removed in this PR.

- Ignore `container_definitions` on `aws_ecs_task_definition` by default
- Add inline comments for how to manually manage ECS service and task definitions redeploys in terraform

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

We have a confluence of factors that makes CD a little challenging:
- I would like us to use immutable docker image tags so that we can more easily trace which image has been deployed to which environment at what time
- I would like us to grant the Github Actions AWS IAM role as narrow a set of permissions as possible so that we aren't granting the machine user full permissions to run `terraform apply`
- I would like Github Actions to be able to build new docker images and deploy them to any of our environments so that we can support continuous deployment
- I would like to be able to manage _everything else_ about infrastructure in terraform so that we have our infrastructure documented as code

To accomplish this, we have:
- Set ECR image repositories to use immutable tags
- Narrowed down our Github Actions role permissions
- Used the aws-actions Github Actions to deploy updated ECS task definitions
- (so far) Added `task_definition` to the lifecycle ignore_changes block for the ECS service, like so:

```
# in aws_ecs_service
  lifecycle {
    ignore_changes = [
      desired_count,
      task_definition,
    ]
  }
```

However, if this is the _only_ change we ignore, the `aws_ecs_task_definition` will try to update the container definitions to the default image tag if we have previously set it to something else.

This PR adds the following:

```
# in aws_ecs_task_definition
  lifecycle {
    ignore_changes = [
      container_definitions
    ]
  }
```

This change will by default make **NO** changes to the task container definition when running `terraform apply`. 

If you **DO** need to make changes to the task container definition for some reason, you need to manually and **TEMPORARILY** uncomment both of these ignore_changes lines and pass in `-var="image_tag=<correct_image_tag>"`. This has been documented inline.

Note: It would be ideal to control this behavior with a variable that you can pass into `terraform plan`/`terraform apply`. However, `lifecycle` cannot handle expression evaluation or variable interpolation. 😞 See https://github.com/hashicorp/terraform/issues/3116

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

1. `terraform plan` with the default should return no changes for the ECS services and ECS task definitions
2. `terraform plan` with only the `task_definition` line commented out should show that the task definitions want to update the image tags
3. `terraform plan` with both the `task_definition` and `container_definitions` lines commented out should show that the task definitions want to update the image tags AND the services want to point to the new task definitions