### PR TITLE
[PRP-278] Update infra to support participant portal doc upload

### DIFF
--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -228,9 +228,10 @@ module "doc_upload" {
   source            = "../../modules/s3-encrypted"
   environment_name  = var.environment_name
   s3_bucket_name    = local.document_upload_s3_name
-  read_role_names   = [module.participant.task_executor_role_name, module.staff.task_executor_role_name]
-  write_role_names  = [module.participant.task_executor_role_name]
-  delete_role_names = [module.participant.task_executor_role_name]
+  read_role_names   = [module.participant.task_role_name, module.staff.task_role_name]
+  write_role_names  = [module.participant.task_role_name]
+  delete_role_names = [module.participant.task_role_name]
+  admin_role_names  = [module.participant.task_role_name]
 }
 
 # todo: cleanup service names

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -84,9 +84,29 @@ module "participant" {
   ]
   container_env_vars = [
     {
+      name  = "MAX_UPLOAD_SIZE_BYTES",
+      value = var.participant_max_upload_size_bytes,
+    },
+    {
+      name  = "MAX_UPLOAD_FILECOUNT",
+      value = var.participant_max_upload_filecount,
+    },
+    {
+      name  = "MAX_SESSION_SECONDS",
+      value = var.participant_max_session_seconds,
+    },
+    {
+      name  = "AWS_REGION",
+      value = data.aws_region.current.name,
+    },
+    {
+      name  = "S3_BUCKET",
+      value = local.document_upload_s3_name,
+    },
+    {
       name  = "PUBLIC_DEMO_MODE",
-      value = false
-    }
+      value = false,
+    },
   ]
   service_ssm_resource_paths = [
     module.participant_database.admin_db_url_secret_name,
@@ -180,8 +200,8 @@ module "analytics" {
   container_env_vars = [
     {
       name  = "MATOMO_DATABASE_DBNAME",
-      value = local.analytics_database_name
-    }
+      value = local.analytics_database_name,
+    },
   ]
   service_ssm_resource_paths = [
     module.analytics_database.admin_db_host_secret_name,
@@ -210,7 +230,7 @@ module "doc_upload" {
   s3_bucket_name    = local.document_upload_s3_name
   read_role_names   = [module.participant.task_executor_role_name, module.staff.task_executor_role_name]
   write_role_names  = [module.participant.task_executor_role_name]
-  delete_role_names = []
+  delete_role_names = [module.participant.task_executor_role_name]
 }
 
 # todo: cleanup service names

--- a/infra/app/env-template/variables.tf
+++ b/infra/app/env-template/variables.tf
@@ -1,24 +1,42 @@
+##############################################
+## General variables
+##############################################
 variable "environment_name" {
   type        = string
   description = "name of the application environment"
 }
 
+
+##############################################
+## Variables for the participant app
+##############################################
 variable "participant_image_tag" {
   type        = string
   description = "Image tag to deploy to the environment for the participant service"
   default     = "latest"
 }
 
-variable "staff_image_tag" {
+variable "participant_url" {
   type        = string
-  description = "Image tag to deploy to the environment for the staff service"
-  default     = "latest"
+  description = "URL to access the application"
 }
 
-variable "analytics_image_tag" {
+variable "participant_max_upload_size_bytes" {
   type        = string
-  description = "Image tag to deploy to the environment for the analytics service"
-  default     = "latest"
+  description = "The maximum allowed size of a single file upload"
+  default     = "26_214_400"
+}
+
+variable "participant_max_upload_filecount" {
+  type        = string
+  description = "The maximum allowed number of files per submission"
+  default     = "20"
+}
+
+variable "participant_max_session_seconds" {
+  type        = string
+  description = "The maximum allowed number of seconds per session (aka session timeout limit in seconds)"
+  default     = "1800"
 }
 
 variable "participant_enable_exec" {
@@ -27,29 +45,44 @@ variable "participant_enable_exec" {
   default     = false
 }
 
+
+##############################################
+## Variables for the staff app
+##############################################
+variable "staff_image_tag" {
+  type        = string
+  description = "Image tag to deploy to the environment for the staff service"
+  default     = "latest"
+}
+
+variable "staff_url" {
+  type        = string
+  description = "URL to access the application"
+}
+
 variable "staff_enable_exec" {
   type        = bool
   description = "Enables ECS exec for the staff service"
   default     = false
 }
 
+
+##############################################
+## Variables for the analytics app
+##############################################
+variable "analytics_image_tag" {
+  type        = string
+  description = "Image tag to deploy to the environment for the analytics service"
+  default     = "latest"
+}
+
+variable "analytics_url" {
+  type        = string
+  description = "URL to access the application"
+}
+
 variable "analytics_enable_exec" {
   type        = bool
   description = "Enables ECS exec for the analytics service"
   default     = false
-}
-variable "participant_url" {
-  type        = string
-  description = "URL to access the application"
-  default     = "dev.wic-services.org"
-}
-variable "staff_url" {
-  type        = string
-  description = "URL to access the application"
-  default     = "dev-staff.wic-services.org"
-}
-variable "analytics_url" {
-  type        = string
-  description = "URL to access the application"
-  default     = "dev-analytics.wic-services.org"
 }

--- a/infra/app/env-template/variables.tf
+++ b/infra/app/env-template/variables.tf
@@ -24,7 +24,7 @@ variable "participant_url" {
 variable "participant_max_upload_size_bytes" {
   type        = string
   description = "The maximum allowed size of a single file upload"
-  default     = "26_214_400"
+  default     = "26214400"
 }
 
 variable "participant_max_upload_filecount" {

--- a/infra/app/envs/dev/main.tf
+++ b/infra/app/envs/dev/main.tf
@@ -55,15 +55,18 @@ module "app" {
   source           = "../../env-template"
   environment_name = local.environment_name
 
-  participant_image_tag             = var.participant_image_tag
-  participant_url                   = "${local.environment_name}.wic-services.org"
+  # Image tags
+  participant_image_tag = var.participant_image_tag
+  staff_image_tag       = var.staff_image_tag
+  analytics_image_tag   = var.analytics_image_tag
+
+  # Urls
+  participant_url = "${local.environment_name}.wic-services.org"
+  staff_url       = "${local.environment_name}-staff.wic-services.org"
+  analytics_url   = "${local.environment_name}-analytics.wic-services.org"
+
+  # Misc settings
   participant_max_upload_size_bytes = "5242880"
   participant_max_upload_filecount  = "5"
-
-  staff_image_tag = var.staff_image_tag
-  staff_url       = "${local.environment_name}-staff.wic-services.org"
-
-  analytics_image_tag   = var.analytics_image_tag
-  analytics_url         = "${local.environment_name}-analytics.wic-services.org"
-  analytics_enable_exec = true
+  analytics_enable_exec             = true
 }

--- a/infra/app/envs/dev/main.tf
+++ b/infra/app/envs/dev/main.tf
@@ -52,13 +52,18 @@ module "project_config" {
 }
 
 module "app" {
-  source                = "../../env-template"
-  environment_name      = local.environment_name
-  participant_image_tag = var.participant_image_tag
-  staff_image_tag       = var.staff_image_tag
+  source           = "../../env-template"
+  environment_name = local.environment_name
+
+  participant_image_tag             = var.participant_image_tag
+  participant_url                   = "${local.environment_name}.wic-services.org"
+  participant_max_upload_size_bytes = "5242880"
+  participant_max_upload_filecount  = "5"
+
+  staff_image_tag = var.staff_image_tag
+  staff_url       = "${local.environment_name}-staff.wic-services.org"
+
   analytics_image_tag   = var.analytics_image_tag
-  analytics_enable_exec = true
-  participant_url       = "${local.environment_name}.wic-services.org"
-  staff_url             = "${local.environment_name}-staff.wic-services.org"
   analytics_url         = "${local.environment_name}-analytics.wic-services.org"
+  analytics_enable_exec = true
 }

--- a/infra/app/envs/prod/main.tf
+++ b/infra/app/envs/prod/main.tf
@@ -52,12 +52,16 @@ module "project_config" {
 
 # Add application modules below
 module "app" {
-  source                = "../../env-template"
-  environment_name      = local.environment_name
+  source           = "../../env-template"
+  environment_name = local.environment_name
+
+  # Image tags
   participant_image_tag = var.participant_image_tag
   staff_image_tag       = var.staff_image_tag
   analytics_image_tag   = var.analytics_image_tag
-  participant_url       = "wic-services.org"
-  staff_url             = "staff.wic-services.org"
-  analytics_url         = "analytics.wic-services.org"
+
+  # Urls
+  participant_url = "wic-services.org"
+  staff_url       = "staff.wic-services.org"
+  analytics_url   = "analytics.wic-services.org"
 }

--- a/infra/app/envs/staging/main.tf
+++ b/infra/app/envs/staging/main.tf
@@ -50,13 +50,18 @@ module "project_config" {
 
 # Add application modules below
 module "app" {
-  source                = "../../env-template"
-  environment_name      = local.environment_name
-  participant_image_tag = var.participant_image_tag
-  staff_image_tag       = var.staff_image_tag
+  source           = "../../env-template"
+  environment_name = local.environment_name
+
+  participant_image_tag             = var.participant_image_tag
+  participant_url                   = "${local.environment_name}.wic-services.org"
+  participant_max_upload_size_bytes = "5242880"
+  participant_max_upload_filecount  = "5"
+
+  staff_image_tag = var.staff_image_tag
+  staff_url       = "${local.environment_name}-staff.wic-services.org"
+
   analytics_image_tag   = var.analytics_image_tag
-  analytics_enable_exec = true
-  participant_url       = "${local.environment_name}.wic-services.org"
-  staff_url             = "${local.environment_name}-staff.wic-services.org"
   analytics_url         = "${local.environment_name}-analytics.wic-services.org"
+  analytics_enable_exec = true
 }

--- a/infra/app/envs/staging/main.tf
+++ b/infra/app/envs/staging/main.tf
@@ -53,15 +53,16 @@ module "app" {
   source           = "../../env-template"
   environment_name = local.environment_name
 
-  participant_image_tag             = var.participant_image_tag
-  participant_url                   = "${local.environment_name}.wic-services.org"
-  participant_max_upload_size_bytes = "5242880"
-  participant_max_upload_filecount  = "5"
-
-  staff_image_tag = var.staff_image_tag
-  staff_url       = "${local.environment_name}-staff.wic-services.org"
-
+  # Image tags
+  participant_image_tag = var.participant_image_tag
+  staff_image_tag       = var.staff_image_tag
   analytics_image_tag   = var.analytics_image_tag
-  analytics_url         = "${local.environment_name}-analytics.wic-services.org"
+
+  # Urls
+  participant_url = "${local.environment_name}.wic-services.org"
+  staff_url       = "${local.environment_name}-staff.wic-services.org"
+  analytics_url   = "${local.environment_name}-analytics.wic-services.org"
+
+  # Misc settings
   analytics_enable_exec = true
 }

--- a/infra/modules/s3-encrypted/variables.tf
+++ b/infra/modules/s3-encrypted/variables.tf
@@ -21,6 +21,12 @@ variable "read_role_names" {
   default     = []
 }
 
+variable "admin_role_names" {
+  type        = list(string)
+  description = "role names that have access to admin s3 permissions, such as creating buckets"
+  default     = []
+}
+
 variable "s3_bucket_name" {
   type        = string
   description = "The s3 bucket used for document uploads"

--- a/infra/modules/service/outputs.tf
+++ b/infra/modules/service/outputs.tf
@@ -1,3 +1,3 @@
-output "task_executor_role_name" {
-  value = aws_iam_role.task_executor.name
+output "task_role_name" {
+  value = aws_iam_role.task.name
 }

--- a/participant/app/utils/s3.connection.ts
+++ b/participant/app/utils/s3.connection.ts
@@ -31,6 +31,8 @@ export const createS3Client = (): S3Client => {
   }
 };
 
+// @TODO: We should rewrite this function so that the participant portal
+// doesn't need to have permissions to create the bucket.
 export const ensureBucketExists = async (s3Client: S3Client) => {
   if (!global.__bucket_ensured) {
     console.log(`🪣 🛠️ Trying to create S3 Bucket ${BUCKET}`);


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-278

## Changes
> What was added, updated, or removed in this PR.

- Add new environment variables needed for doc upload in the participant portal
- Grant participant ECS task IAM higher level permissions to s3 bucket
- Set participant max file limit and max file size lower in dev and staging
- Always define a task IAM role for ECS tasks, even though sometimes they won't need it
- Attach the s3 permissions to the task role, not the task executor role

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

These changes have been deployed to the dev environment. To test:
- Navigate to dev.wic-services.org/gallatin/recertify/changes and upload a document
- The upload should work and not error in the browser
- Go to the s3 bucket and see your document has been uploaded
