### PR TITLE
[PRP-286] Pin to infra CI to checkov latest release (v2.3.194)

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -46,7 +46,11 @@ jobs:
         with:
           python-version: "3.10"
       - name: Run Checkov check
-        uses: bridgecrewio/checkov-action@master
+        # Pins to checkov-action v12.2296.0
+        # which in turn pins to checkov v2.3.194
+        # which is the latest release version at time of commit:
+        # - https://github.com/bridgecrewio/checkov/releases/tag/2.3.194
+        uses: bridgecrewio/checkov-action@12.2296.0
         with:
           directory: infra
           framework: terraform

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -50,7 +50,7 @@ jobs:
         # which in turn pins to checkov v2.3.194
         # which is the latest release version at time of commit:
         # - https://github.com/bridgecrewio/checkov/releases/tag/2.3.194
-        uses: bridgecrewio/checkov-action@12.2296.0
+        uses: bridgecrewio/checkov-action@v12.2296.0
         with:
           directory: infra
           framework: terraform


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-286

## Changes
> What was added, updated, or removed in this PR.

- Pin CI checkov check to latest checkov release (v2.3.194)

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Right now we’re doing infra checks against [checkov@main](https://github.com/bridgecrewio/checkov) and it’s a little bit chaos because every PR has a chance of randomly failing against brand new checkov checks. This PR pins to a specific version and https://wicmtdp.atlassian.net/browse/PRP-287 will handle updating to a future latest version.

There is currently no way to specify the checkov version to the checkov-action. See open issue: https://github.com/bridgecrewio/checkov-action/issues/41

So, instead, this PR pins to:
- Latest released version of checkov is [v2.3.194](https://github.com/bridgecrewio/checkov/releases/tag/2.3.194)
- Latest matching release version of checkov-action is [v12.2296.0](https://github.com/bridgecrewio/checkov-action/releases/tag/v12.2296.0)

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

See passing CI check at: https://github.com/navapbc/wic-participant-recertification-portal/actions/runs/4789903100/jobs/8518320846?pr=67