### PR TITLE
[PRP-288] Refactor staff creation scripts to be more durable across environments

### DIFF
--- a/infra/modules/cognito-staff-user/create-staff-users.sh
+++ b/infra/modules/cognito-staff-user/create-staff-users.sh
@@ -5,6 +5,7 @@
 # - the path to a json file that maps local agencies and emails (which are used as the username).
 # See below for more details.
 # Example: ./create-staff-users dev /tmp/email.json
+# @TODO: This might possibly be better if this were pulled down from an S3 bucket.
 set -euo pipefail
 
 # Positional arguments.
@@ -14,37 +15,22 @@ ENV_NAME=$1
 # The Cognito process needs a file with the emails for each local agency. This must be provided.
 # Do not commit this file to git! Pass in the path to a file of the format:
 # {
-#   "<local_agency_url_id>": [
-#     "email",
-#     "email",
-#     "email"
-#   ]
+#   "user_emails": {
+#     "<email>": "<local agency>"
 # }
 #
 # For example:
 # {
-#   "gallatin": [
-#     "apple@wic.gov",
-#     "carrot@wic.gov"
-#     "eggplant@wic.gov"
-#   ],
-#   "missoula": [
-#     "banana@wic.gov",
-#     "daikonwic.gov",
-#   ]
+#   "user_emails": {
+#     "apple@wic.gov": "gallatin",
+#     "carrot@wic.gov": "gallatin",
+#     "eggplant@wic.gov": "gallatin",
+#     "banana@wic.gov": "missoula",
+#     "daikon@wic.gov": "missoula",
 # }
 EMAIL_FILENAME=$2
 
 # Variables.
-# The emails get transformed into this format for terraform to ingest:
-# {
-#   "apple@wic.gov": "gallatin",
-#   "carrot@wic.gov": "gallatin",
-#   "eggplant@wic.gov": "gallatin",
-#   "banana@wic.gov": "missoula",
-#   "daikon@wic.gov": "missoula"
-# }
-TRANSFORMED_USER_EMAILS=$(jq '[to_entries[] | {(.value[]): .key}] | add' $EMAIL_FILENAME)
 UUID_FILENAME="staff-uuids-to-agencies.json"
 USER_POOL_NAME="wic-prp-staff-${ENV_NAME}"
 CLUSTER_NAME="wic-prp-app-${ENV_NAME}"
@@ -55,15 +41,22 @@ BUCKET_NAME="wic-prp-side-load-${ENV_NAME}"
 
 
 # # Create staff users in cognito.
+echo "Selecting workspace ${ENV_NAME}..."
+terraform workspace select $ENV_NAME
+echo "Running terraform init..."
 terraform init
+
+echo "Running terraform apply..."
 terraform apply \
-  -var="user_pool_name=${USER_POOL_NAME}" \
-  -var="user_emails=${TRANSFORMED_USER_EMAILS}"
+  -var="environment_name=${ENV_NAME}" \
+  -var-file=$EMAIL_FILENAME \
+  -var="user_pool_name=${USER_POOL_NAME}"
 
 # Save output to s3.
 # The ECS Task process needs a file that maps Cognito UUIDs to local agencies. This is automatically created and
 # temporarily saved locally. It will be cleaned up as the last step.
 terraform output -json | jq .staff_user_list.value > $UUID_FILENAME
+echo "Uploading seed file to s3..."
 aws s3api put-object \
   --bucket $BUCKET_NAME \
   --key "seed/${UUID_FILENAME}" \
@@ -76,6 +69,7 @@ CONTAINER_OVERRIDES="{ \"containerOverrides\": [{ \"name\": \"${CONTAINER_NAME}\
 # Import staff users into participant database.
 # Run as a one-off ECS task.
 # Logs can be viewed in Cloudwatch.
+echo "Running one-off ecs task..."
 aws ecs run-task \
   --cluster $CLUSTER_NAME \
   --task-definition $TASK_DEFINITION_NAME \
@@ -85,4 +79,7 @@ aws ecs run-task \
   --platform-version="1.4.0"
 
 # Cleanup
+echo "Removing temporary file..."
 rm $UUID_FILENAME
+
+echo "... Done!"

--- a/infra/modules/cognito-staff-user/main.tf
+++ b/infra/modules/cognito-staff-user/main.tf
@@ -1,3 +1,51 @@
+locals {
+  environment_name = var.environment_name
+  # The prefix key/value pair is used for Terraform Workspaces, which is useful for projects with multiple infrastructure developers.
+  # By default, Terraform creates a workspace named “default.” If a non-default workspace is not created this prefix will equal “default”,
+  # if you choose not to use workspaces set this value to "dev"
+  prefix = terraform.workspace
+  # Choose the region where this infrastructure should be deployed.
+  region = "us-west-2"
+  # Add environment specific tags
+  tags = merge(module.project_config.default_tags, {
+    environment = local.environment_name
+    description = "Cognito user resources created in ${var.environment_name} environment"
+  })
+}
+
+terraform {
+  required_version = ">=1.2.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=4.59.0"
+    }
+  }
+
+  # Terraform does not allow interpolation here, values must be hardcoded.
+
+  backend "s3" {
+    bucket         = "wic-prp-636249768232-us-west-2-tf-state"
+    key            = "infra/wic-prp/cognito-staff-user.tfstate"
+    dynamodb_table = "wic-prp-tf-state-locks"
+    region         = "us-west-2"
+    encrypt        = "true"
+    workspace_key_prefix  = "workspace"
+  }
+}
+
+provider "aws" {
+  region = local.region
+  default_tags {
+    tags = local.tags
+  }
+}
+
+module "project_config" {
+  source = "../../project-config"
+}
+
 data "aws_cognito_user_pools" "pool" {
   name = var.user_pool_name
 }

--- a/infra/modules/cognito-staff-user/main.tf
+++ b/infra/modules/cognito-staff-user/main.tf
@@ -26,12 +26,12 @@ terraform {
   # Terraform does not allow interpolation here, values must be hardcoded.
 
   backend "s3" {
-    bucket         = "wic-prp-636249768232-us-west-2-tf-state"
-    key            = "infra/wic-prp/cognito-staff-user.tfstate"
-    dynamodb_table = "wic-prp-tf-state-locks"
-    region         = "us-west-2"
-    encrypt        = "true"
-    workspace_key_prefix  = "workspace"
+    bucket               = "wic-prp-636249768232-us-west-2-tf-state"
+    key                  = "infra/wic-prp/cognito-staff-user.tfstate"
+    dynamodb_table       = "wic-prp-tf-state-locks"
+    region               = "us-west-2"
+    encrypt              = "true"
+    workspace_key_prefix = "workspace"
   }
 }
 

--- a/infra/modules/cognito-staff-user/outputs.tf
+++ b/infra/modules/cognito-staff-user/outputs.tf
@@ -1,3 +1,11 @@
+output "user_pool_name" {
+  value = var.user_pool_name
+}
+
+output "user_pool_id" {
+  value = data.aws_cognito_user_pools.pool.ids[0]
+}
+
 output "staff_user_list" {
   value = [for user in aws_cognito_user.user : {
     "staffUserId" : user.sub,

--- a/infra/modules/cognito-staff-user/variables.tf
+++ b/infra/modules/cognito-staff-user/variables.tf
@@ -1,3 +1,7 @@
+variable "environment_name" {
+  type = string
+}
+
 variable "user_pool_name" {
   type        = string
   description = "The name of the user pool the users should be created in"
@@ -12,4 +16,5 @@ variable "temporary_password_length" {
 variable "user_emails" {
   type        = map(any)
   description = "A mapping of emails addresses for users to create to the local agency they belong to. For example {'email@email.com': 'local_agency_a'}."
+  default = {}
 }

--- a/infra/modules/cognito-staff-user/variables.tf
+++ b/infra/modules/cognito-staff-user/variables.tf
@@ -16,5 +16,5 @@ variable "temporary_password_length" {
 variable "user_emails" {
   type        = map(any)
   description = "A mapping of emails addresses for users to create to the local agency they belong to. For example {'email@email.com': 'local_agency_a'}."
-  default = {}
+  default     = {}
 }


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-288

## Changes
> What was added, updated, or removed in this PR.

- Refactor create staff user module to use terraform workspaces

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This PR has been deployed and used. It is a bit of a frankenstein monster and introduces workspaces into our infra set up in a piecemeal way 😱 

Creating users previously was a failure in one of two ways:
1. The user previously existed and `terraform apply` crashed, causing the rest of the script to fail (this was the reason our test users in the staging environment weren't associated with local agencies)
2. The users would be created in the specified environment at the cost of deleting the users in the other environments

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
