### PR TITLE
[PRP-300, 301, 302, 305, 306] Staff portal bug bash 2023-04-27 fixes

### DIFF
--- a/infra/app/envs/dev/main.tf
+++ b/infra/app/envs/dev/main.tf
@@ -66,7 +66,7 @@ module "app" {
   analytics_url   = "${local.environment_name}-analytics.wic-services.org"
 
   # Misc settings
-  participant_max_upload_size_bytes       = "5242880"
-  participant_max_upload_filecount        = "5"
-  analytics_enable_exec                   = true
+  participant_max_upload_size_bytes = "5242880"
+  participant_max_upload_filecount  = "5"
+  analytics_enable_exec             = true
 }

--- a/infra/app/envs/dev/main.tf
+++ b/infra/app/envs/dev/main.tf
@@ -66,7 +66,6 @@ module "app" {
   analytics_url   = "${local.environment_name}-analytics.wic-services.org"
 
   # Misc settings
-  participant_s3_presigned_url_expiration = "300"
   participant_max_upload_size_bytes       = "5242880"
   participant_max_upload_filecount        = "5"
   analytics_enable_exec                   = true

--- a/participant/prisma/seed.ts
+++ b/participant/prisma/seed.ts
@@ -150,7 +150,11 @@ async function seed() {
     const localAgency = await findLocalAgency(seedAgencyUrlId);
     if (localAgency) {
       for (const seedSubmission of seedAgencySubmissions) {
-        await upsertSubmission(seedSubmission.submissionId, localAgency.urlId, seedSubmission.submitted);
+        await upsertSubmission(
+          seedSubmission.submissionId,
+          localAgency.urlId,
+          seedSubmission.submitted
+        );
         for (let [seedFormRoute, seedFormData] of Object.entries(
           seedSubmission.forms
         )) {

--- a/participant/prisma/seed.ts
+++ b/participant/prisma/seed.ts
@@ -28,7 +28,7 @@ export type NameFormType = {
 };
 
 export type SeedDataType = {
-  [key: string]: string;
+  [key: string]: string | number;
 };
 
 export type SeedSubmissionFormsType = {

--- a/participant/prisma/seed.ts
+++ b/participant/prisma/seed.ts
@@ -45,6 +45,7 @@ export type SeedDocumentType = {
 
 export type SeedAgencySubmissionsType = {
   submissionId: string;
+  submitted: boolean;
   forms: SeedSubmissionFormsType;
   documents: SeedDocumentType[];
 };
@@ -137,6 +138,8 @@ async function seed() {
     if (!localAgency || localAgency.name != seedAgency.name) {
       await upsertLocalAgency(seedAgency.urlId, seedAgency.name);
       console.log(`Seeding localAgency: ${seedAgency.urlId} 🌱`);
+    } else {
+      console.log(`No need to seed localAgency: ${seedAgency.urlId} 🪴`);
     }
   }
 
@@ -147,7 +150,7 @@ async function seed() {
     const localAgency = await findLocalAgency(seedAgencyUrlId);
     if (localAgency) {
       for (const seedSubmission of seedAgencySubmissions) {
-        await upsertSubmission(seedSubmission.submissionId, localAgency.urlId);
+        await upsertSubmission(seedSubmission.submissionId, localAgency.urlId, seedSubmission.submitted);
         for (let [seedFormRoute, seedFormData] of Object.entries(
           seedSubmission.forms
         )) {

--- a/participant/public/data/submissions.not-prod.json
+++ b/participant/public/data/submissions.not-prod.json
@@ -2,6 +2,7 @@
   "gallatin": [
     {
       "submissionId": "8795e9f3-32c8-4ecc-963a-8ebc606e58e6",
+      "submitted": true,
       "forms": {
         "name": {
           "firstName": "Abigail",
@@ -45,6 +46,7 @@
     },
     {
       "submissionId": "f29c1ffd-a148-4a58-9592-064a0b990e7e",
+      "submitted": true,
       "forms": {
         "name": {
           "firstName": "Nicholas",
@@ -107,6 +109,7 @@
   "missoula": [
     {
       "submissionId": "67eecabe-ed37-4ff7-a9ac-6b3e19a5c72c",
+      "submitted": true,
       "forms": {
         "name": {
           "firstName": "Elizabeth",

--- a/participant/public/data/submissions.not-prod.json
+++ b/participant/public/data/submissions.not-prod.json
@@ -21,7 +21,7 @@
             "firstName": "Mandy",
             "lastName": "Cho",
             "dateOfBirth": "04/02/2022",
-            "adjunctive": ""
+            "adjunctive": "no"
           }
         ],
         "contact": {
@@ -67,28 +67,28 @@
             "lastName": "Brown",
             "preferredName": "Nick Brown",
             "dateOfBirth": "07/03/1993",
-            "adjunctive": "snap"
+            "adjunctive": "yes"
           },
           {
             "relationship": "child",
             "firstName": "Zoe",
             "lastName": "Brown",
             "dateOfBirth": "03/03/2020",
-            "adjunctive": "snap"
+            "adjunctive": "yes"
           },
           {
             "relationship": "child",
             "firstName": "Mia",
             "lastName": "Brown",
             "dateOfBirth": "03/03/2020",
-            "adjunctive": "snap"
+            "adjunctive": "yes"
           },
           {
             "relationship": "child",
             "firstName": "Mason",
             "lastName": "Brown",
             "dateOfBirth": "10/14/2022",
-            "adjunctive": "snap"
+            "adjunctive": "yes"
           }
         ],
         "contact": {
@@ -130,14 +130,14 @@
             "lastName": "Schneider",
             "preferredName": "Liz",
             "dateOfBirth": "11/21/1990",
-            "adjunctive": "fdpir"
+            "adjunctive": "yes"
           },
           {
             "relationship": "child",
             "firstName": "Seth",
             "lastName": "Schneider",
             "dateOfBirth": "02/23/2023",
-            "adjunctive": "fdpir"
+            "adjunctive": "yes"
           }
         ],
         "contact": {

--- a/participant/public/data/submissions.not-prod.json
+++ b/participant/public/data/submissions.not-prod.json
@@ -20,7 +20,11 @@
             "relationship": "child",
             "firstName": "Mandy",
             "lastName": "Cho",
-            "dateOfBirth": "04/02/2022",
+            "dob": {
+              "day": 2,
+              "month": 4,
+              "year": 2022
+            },
             "adjunctive": "no"
           }
         ],
@@ -66,28 +70,44 @@
             "firstName": "Nicholas",
             "lastName": "Brown",
             "preferredName": "Nick Brown",
-            "dateOfBirth": "07/03/1993",
+            "dob": {
+              "day": 3,
+              "month": 7,
+              "year": 1993
+            },
             "adjunctive": "yes"
           },
           {
             "relationship": "child",
             "firstName": "Zoe",
             "lastName": "Brown",
-            "dateOfBirth": "03/03/2020",
+            "dob": {
+              "day": 3,
+              "month": 3,
+              "year": 2020
+            },
             "adjunctive": "yes"
           },
           {
             "relationship": "child",
             "firstName": "Mia",
             "lastName": "Brown",
-            "dateOfBirth": "03/03/2020",
+            "dob": {
+              "day": 3,
+              "month": 3,
+              "year": 2020
+            },
             "adjunctive": "yes"
           },
           {
             "relationship": "child",
             "firstName": "Mason",
             "lastName": "Brown",
-            "dateOfBirth": "10/14/2022",
+            "dob": {
+              "day": 14,
+              "month": 10,
+              "year": 2022
+            },
             "adjunctive": "yes"
           }
         ],
@@ -129,14 +149,22 @@
             "firstName": "Elizabeth",
             "lastName": "Schneider",
             "preferredName": "Liz",
-            "dateOfBirth": "11/21/1990",
+            "dob": {
+              "day": 21,
+              "month": 11,
+              "year": 1990
+            },
             "adjunctive": "yes"
           },
           {
             "relationship": "child",
             "firstName": "Seth",
             "lastName": "Schneider",
-            "dateOfBirth": "02/23/2023",
+            "dob": {
+              "day": 23,
+              "month": 2,
+              "year": 2023
+            },
             "adjunctive": "yes"
           }
         ],

--- a/staff/pages/recert.yml
+++ b/staff/pages/recert.yml
@@ -177,11 +177,8 @@ blocks:
                   {% for participant in details %}
                   {{ participant.lastName }}, {{ participant.firstName }} {{ "(" + participant.preferredName + ")" if participant.preferredName }}
                   Relationship to contact person:
-                  {%- if participant.relationship == "self" %} Self
-                  {%- elif participant.relationship == "child" %} Child
-                  {%- elif participant.relationship == "grandchild" %} Grandchild
-                  {%- elif participant.relationship == "foster" %} Foster child
-                  {%- else %} Other
+                  {% if participant.relationship == "foster" -%} Foster child
+                  {% else -%} {{ participant.relationship | title }}
                   {%- endif %}
                   Date of birth: {{ participant.dateOfBirth }}
                   Adjunctive eligibility: {{ "Yes" if participant.adjunctive != "" else "No" }}
@@ -202,17 +199,9 @@ blocks:
                       </div>
                       <ul>
                         <li class="relationship">Relationship to contact person:
-                          {% if participant.relationship == "self" %}
-                            Self
-                          {% elif participant.relationship == "child" %}
-                            Child
-                          {% elif participant.relationship == "grandchild" %}
-                            Grandchild
-                          {% elif participant.relationship == "foster" %}
-                            Foster child
-                          {% else %}
-                            Other
-                          {% endif %}
+                          {% if participant.relationship == "foster" -%} Foster child
+                          {% else -%} {{ participant.relationship | title }}
+                          {%- endif %}
                         </li>
                         <li class="date-of-birth">Date of birth: {{ participant.dateOfBirth }}</li>
                         <li class="adjunctive">Adjunctive eligibility:

--- a/staff/pages/recert.yml
+++ b/staff/pages/recert.yml
@@ -180,7 +180,7 @@ blocks:
                   {% if participant.relationship == "foster" -%} Foster child
                   {% else -%} {{ participant.relationship | title }}
                   {%- endif %}
-                  Date of birth: {{ participant.dateOfBirth }}
+                  Date of birth: {{ participant.dob.month }}/{{ participant.dob.day }}/{{ participant.dob.year }}
                   Adjunctive eligibility: {{ participant.adjunctive | title }}
                   {% endfor -%}
                 on:
@@ -203,7 +203,7 @@ blocks:
                           {% else -%} {{ participant.relationship | title }}
                           {%- endif %}
                         </li>
-                        <li class="date-of-birth">Date of birth: {{ participant.dateOfBirth }}</li>
+                        <li class="date-of-birth">Date of birth: {{ participant.dob.month }}/{{ participant.dob.day }}/{{ participant.dob.year }}</li>
                         <li class="adjunctive">Adjunctive eligibility:
                           {{ participant.adjunctive | title }}
                         </li>

--- a/staff/pages/recert.yml
+++ b/staff/pages/recert.yml
@@ -22,6 +22,7 @@ requests: # Requests defines all the data requests made available in this page c
         ) d on (s.submission_id = d.submission_id)
         left join staff_users su on (s.local_agency_id = su.local_agency_id)
         where su.staff_user_id = :staff_user_id
+        and s.submitted = true
         group by sf.submission_id, s.updated_at, la.name, d.s3_documents
         order by s.updated_at desc;
       parameters:

--- a/staff/pages/recert.yml
+++ b/staff/pages/recert.yml
@@ -181,7 +181,7 @@ blocks:
                   {% else -%} {{ participant.relationship | title }}
                   {%- endif %}
                   Date of birth: {{ participant.dateOfBirth }}
-                  Adjunctive eligibility: {{ "Yes" if participant.adjunctive != "" else "No" }}
+                  Adjunctive eligibility: {{ participant.adjunctive | title }}
                   {% endfor -%}
                 on:
                   __args: 0.data.form_data
@@ -205,11 +205,7 @@ blocks:
                         </li>
                         <li class="date-of-birth">Date of birth: {{ participant.dateOfBirth }}</li>
                         <li class="adjunctive">Adjunctive eligibility:
-                          {% if participant.adjunctive != "" %}
-                            Yes
-                          {% else %}
-                            No
-                          {% endif %}
+                          {{ participant.adjunctive | title }}
                         </li>
                       </ul>
                     </div>

--- a/staff/pages/recert.yml
+++ b/staff/pages/recert.yml
@@ -247,18 +247,17 @@ blocks:
           field:
           valueGetter:
             _function:
-              __log:
-                __nunjucks:
-                  template: |
-                    {%- if s3_documents %}
-                    {%- for filename, url in s3_documents %}
-                    {{ filename }}{% if not loop.last -%},{%- endif -%}
-                    {% endfor -%}
-                    {%- else -%}
-                    No documents required
-                    {%- endif -%}
-                  on:
-                    __args: 0.data
+              __nunjucks:
+                template: |
+                  {%- if s3_documents %}
+                  {%- for filename, url in s3_documents %}
+                  {{ filename }}{% if not loop.last -%},{%- endif -%}
+                  {% endfor -%}
+                  {%- else -%}
+                  No documents required
+                  {%- endif -%}
+                on:
+                  __args: 0.data
           cellRenderer:
             _function:
               __nunjucks:


### PR DESCRIPTION
## Ticket

- https://wicmtdp.atlassian.net/browse/PRP-300
- https://wicmtdp.atlassian.net/browse/PRP-301
- https://wicmtdp.atlassian.net/browse/PRP-302
- https://wicmtdp.atlassian.net/browse/PRP-305
- https://wicmtdp.atlassian.net/browse/PRP-306

## Changes
> What was added, updated, or removed in this PR.

- Remove the s3 presigned url expiration time override in the `dev` environment
- Fix staff portal database query to only show submitted records
- Fix staff portal rendering of participant adjunctive eligibility and date of birth
- Update submission seed data

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

In the 2023-04-27 bug bash, we found a number of fixes we wanted to make to the staff portal.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
![Screenshot 2023-04-28 at 11-31-48 Montana WIC Staff Portal](https://user-images.githubusercontent.com/67701/235226158-1a8e6029-1267-4532-8d92-e190d6b0a144.png)

