### PR TITLE
PRP-304 Fix Redirect

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -461,8 +461,15 @@ resource "aws_security_group" "alb" {
   }
 
   vpc_id = var.vpc_id
+  # checkov:skip=CKV_AWS_260: HTTP redirect won't work unless the security group allows port 80 traffic
+  ingress {
+    description = "Allow HTTP traffic from public internet"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-  # TODO(https://github.com/navapbc/template-infra/issues/163) Disallow incoming traffic to port 80
   ingress {
     description = "Allow HTTPS traffic from public internet"
     from_port   = 443


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-304

## Changes
* added port 80 ingress to security group
* disabled checkov check that requires no port 80 access

## Context for reviewers
> http://dev.wic-services.org/ fails to correctly redirect to https://dev.wic-services.org/. This is probably happening for all our applications.

## Testing
1. In the AWS console, make sure that the security groups for the services (9 total) have port 80 access from anywhere
2. In your browser, open the inspector and try accessing one of the services from any environment from the http address. There should be a redirect call. 
