### PR TITLE
PRP-89 Handle Database logging (part 1)

### DIFF
--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -33,7 +33,7 @@ resource "aws_rds_cluster_parameter_group" "rds_query_logging_postgresql" {
 
   parameter {
     name  = "log_statement"
-    value = "all"
+    value = "ddl" # Only logs major database changes (e.g. ALTER TABLE)
   }
 
   parameter {


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-89

## Changes

* Change logging statement from `all` to `ddl` 

## Context for reviewers

> Configuration for query logging was added in PRP-13While this is useful for debugging, this may expose sensitive data (e.g. secrets) in the logs. After a later inspection some columns contain sensitive data. Examples can be found in the test database logs with bug bash data. For the sake of time before launch, we are opting to change the logging scheme to only track major database changes. This PR will be followed be research into what the most effective option for database logging is without compromising debugging ability, and then implementation of the best method.

## Testing
N/A
