### PR TITLE
[PRP-314] Format submitted at time on /confirm to local user time

### DIFF
--- a/participant/app/routes/$localAgency/recertify/confirm.tsx
+++ b/participant/app/routes/$localAgency/recertify/confirm.tsx
@@ -16,6 +16,8 @@ import {
   SummaryBoxHeading,
 } from "@trussworks/react-uswds";
 import TransLinks from "~/components/TransLinks";
+import { useHydrated } from "remix-utils";
+import { localizeDateString } from "~/utils/date";
 
 export const loader: LoaderFunction = async ({
   request,
@@ -40,9 +42,7 @@ export const loader: LoaderFunction = async ({
       submissionData: submissionData,
       previouslySubmitted: previouslySubmitted,
       startOverURL: startOverURL,
-      submittedDate: (
-        (submission?.updatedAt as Date) || new Date()
-      ).toLocaleString("en-US"),
+      submittedDate: submission?.updatedAt,
     },
     { headers: headers }
   );
@@ -51,6 +51,14 @@ export const loader: LoaderFunction = async ({
 export default function Confirm() {
   const { submissionData, submittedDate, previouslySubmitted, startOverURL } =
     useLoaderData<typeof loader>();
+
+  // Convert to client local timezone, while avoiding hydration errors.
+  const isHydrated = useHydrated();
+  let convertedSubmittedDate = submittedDate
+  if (isHydrated) {
+    convertedSubmittedDate = localizeDateString(submittedDate)
+  }
+
   const formProps: SubmissionFormProps = {
     editable: false,
     submissionKey: "Review.details",
@@ -83,7 +91,7 @@ export default function Confirm() {
         <strong>
           <Trans i18nKey="Confirm.submitted" />
         </strong>
-        {submittedDate}
+        {convertedSubmittedDate}
       </div>
       <SummaryBox className="margin-bottom-4">
         <SummaryBoxHeading headingLevel="h2">

--- a/participant/app/routes/$localAgency/recertify/confirm.tsx
+++ b/participant/app/routes/$localAgency/recertify/confirm.tsx
@@ -54,9 +54,9 @@ export default function Confirm() {
 
   // Convert to client local timezone, while avoiding hydration errors.
   const isHydrated = useHydrated();
-  let convertedSubmittedDate = submittedDate
+  let convertedSubmittedDate = submittedDate;
   if (isHydrated) {
-    convertedSubmittedDate = localizeDateString(submittedDate)
+    convertedSubmittedDate = localizeDateString(submittedDate);
   }
 
   const formProps: SubmissionFormProps = {

--- a/participant/app/utils/date.ts
+++ b/participant/app/utils/date.ts
@@ -1,0 +1,16 @@
+// This should be called client side to get the client's timezone.
+// If this is called server side, it will get the server's timezone (i.e. UTC).
+
+
+export const localizeDateString = (
+  dateString: string | undefined
+): string => {
+  let localizedString: Date
+  if (dateString === undefined) {
+    localizedString = new Date()
+  } else {
+    localizedString = new Date(dateString)
+  }
+  const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  return localizedString.toLocaleString("en-US", { timeZone: localTimeZone })
+}

--- a/participant/app/utils/date.ts
+++ b/participant/app/utils/date.ts
@@ -1,16 +1,13 @@
 // This should be called client side to get the client's timezone.
 // If this is called server side, it will get the server's timezone (i.e. UTC).
 
-
-export const localizeDateString = (
-  dateString: string | undefined
-): string => {
-  let localizedString: Date
+export const localizeDateString = (dateString: string | undefined): string => {
+  let localizedString: Date;
   if (dateString === undefined) {
-    localizedString = new Date()
+    localizedString = new Date();
   } else {
-    localizedString = new Date(dateString)
+    localizedString = new Date(dateString);
   }
-  const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
-  return localizedString.toLocaleString("en-US", { timeZone: localTimeZone })
-}
+  const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return localizedString.toLocaleString("en-US", { timeZone: localTimeZone });
+};

--- a/participant/tests/utils/date.test.ts
+++ b/participant/tests/utils/date.test.ts
@@ -1,0 +1,31 @@
+import { localizeDateString } from "app/utils/date";
+
+const timezoneMock = function(zone: string) {
+  const DateTimeFormat = Intl.DateTimeFormat
+  jest
+  .spyOn(global.Intl, 'DateTimeFormat')
+  .mockImplementation((locale, options) => new DateTimeFormat(locale, {...options, timeZone: zone}))
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+})
+
+it("should return a correctly localized date string", async () => {
+  timezoneMock("America/Chicago")
+  const dateString = "2023-05-03 18:08:38.653+00"
+  const result = localizeDateString(dateString)
+  expect(result).toStrictEqual("5/3/2023, 1:08:38 PM")
+});
+
+it("should return a correctly localized date string in a different timezone", async () => {
+  timezoneMock("America/Los_Angeles")
+  const dateString = "2023-05-03 18:08:38.653+00"
+  const result = localizeDateString(dateString)
+  expect(result).toStrictEqual("5/3/2023, 11:08:38 AM")
+});
+
+it("should return work if the string is undefined", async () => {
+  const result = localizeDateString(undefined)
+  expect(result).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{1,2}:\d{1,2} (AM|PM)/);
+});

--- a/participant/tests/utils/date.test.ts
+++ b/participant/tests/utils/date.test.ts
@@ -1,31 +1,36 @@
 import { localizeDateString } from "app/utils/date";
 
-const timezoneMock = function(zone: string) {
-  const DateTimeFormat = Intl.DateTimeFormat
+const timezoneMock = function (zone: string) {
+  const DateTimeFormat = Intl.DateTimeFormat;
   jest
-  .spyOn(global.Intl, 'DateTimeFormat')
-  .mockImplementation((locale, options) => new DateTimeFormat(locale, {...options, timeZone: zone}))
-}
+    .spyOn(global.Intl, "DateTimeFormat")
+    .mockImplementation(
+      (locale, options) =>
+        new DateTimeFormat(locale, { ...options, timeZone: zone })
+    );
+};
 
 afterEach(() => {
   jest.restoreAllMocks();
-})
+});
 
 it("should return a correctly localized date string", async () => {
-  timezoneMock("America/Chicago")
-  const dateString = "2023-05-03 18:08:38.653+00"
-  const result = localizeDateString(dateString)
-  expect(result).toStrictEqual("5/3/2023, 1:08:38 PM")
+  timezoneMock("America/Chicago");
+  const dateString = "2023-05-03 18:08:38.653+00";
+  const result = localizeDateString(dateString);
+  expect(result).toStrictEqual("5/3/2023, 1:08:38 PM");
 });
 
 it("should return a correctly localized date string in a different timezone", async () => {
-  timezoneMock("America/Los_Angeles")
-  const dateString = "2023-05-03 18:08:38.653+00"
-  const result = localizeDateString(dateString)
-  expect(result).toStrictEqual("5/3/2023, 11:08:38 AM")
+  timezoneMock("America/Los_Angeles");
+  const dateString = "2023-05-03 18:08:38.653+00";
+  const result = localizeDateString(dateString);
+  expect(result).toStrictEqual("5/3/2023, 11:08:38 AM");
 });
 
 it("should return work if the string is undefined", async () => {
-  const result = localizeDateString(undefined)
-  expect(result).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{1,2}:\d{1,2} (AM|PM)/);
+  const result = localizeDateString(undefined);
+  expect(result).toMatch(
+    /\d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{1,2}:\d{1,2} (AM|PM)/
+  );
 });


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-314

## Changes
> What was added, updated, or removed in this PR.

- Add date util for formatting time
- Use new date util on /upload

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This was surfaced is the 2023-05-02 bug bash.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

1. Checkout this branch
2. Create a submission
3. Confirm the "Form submitted at:" time matches your local user time.

<img width="806" alt="Screenshot 2023-05-03 at 12 51 16 PM" src="https://user-images.githubusercontent.com/67701/236031667-71e1d115-7459-4636-b3e4-85a0648c5bc8.png">

