### PR TITLE
[PRP-327] Prevent healthcheck from making spurious database records

### DIFF
--- a/participant/app/routes/healthcheck.tsx
+++ b/participant/app/routes/healthcheck.tsx
@@ -1,7 +1,6 @@
 // learn more: https://fly.io/docs/reference/configuration/#services-http_checks
 import type { LoaderArgs } from "@remix-run/server-runtime";
 import db from "~/utils/db.connection";
-import invariant from "tiny-invariant";
 
 // Healthcheck returns OK if this resource route is successfully reached
 // AND we are able to connect to the database and make a simple query.

--- a/participant/app/routes/healthcheck.tsx
+++ b/participant/app/routes/healthcheck.tsx
@@ -11,9 +11,7 @@ export async function loader({ request }: LoaderArgs) {
     // here, I encourage you to do so.
     // This is coded as a `SELECT 1` merely for speed
     // and to prevent schema edits from breaking the healthcheck
-    await Promise.all([
-      db.$queryRaw`SELECT 1 as CONNECTED`,
-    ]);
+    await Promise.all([db.$queryRaw`SELECT 1 as CONNECTED`]);
     return new Response("OK");
   } catch (error: unknown) {
     console.log("healthcheck ❌", { error });

--- a/participant/app/routes/healthcheck.tsx
+++ b/participant/app/routes/healthcheck.tsx
@@ -3,25 +3,16 @@ import type { LoaderArgs } from "@remix-run/server-runtime";
 import db from "~/utils/db.connection";
 import invariant from "tiny-invariant";
 
+// Healthcheck returns OK if this resource route is successfully reached
+// AND we are able to connect to the database and make a simple query.
 export async function loader({ request }: LoaderArgs) {
-  const host =
-    request.headers.get("X-Forwarded-Host") ?? request.headers.get("host");
-
   try {
-    invariant(host, "Unable to find host to HEAD");
-    const url = new URL("/", `http://${host}`);
-    // If we can connect to the database and make a simple query
-    // and make a HEAD request to ourselves, then we're good.
-
     // If you want to display the count of some key table data
     // here, I encourage you to do so.
     // This is coded as a `SELECT 1` merely for speed
     // and to prevent schema edits from breaking the healthcheck
     await Promise.all([
       db.$queryRaw`SELECT 1 as CONNECTED`,
-      fetch(url.toString(), { method: "HEAD" }).then((r) => {
-        if (!r.ok) return Promise.reject(r);
-      }),
     ]);
     return new Response("OK");
   } catch (error: unknown) {


### PR DESCRIPTION
## Ticket

- https://wicmtdp.atlassian.net/browse/PRP-327
- https://wicmtdp.atlassian.net/browse/PRP-328

## Changes
> What was added, updated, or removed in this PR.

- Update /healthcheck to not make HEAD requests against /

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

The [resource route](https://remix.run/docs/en/main/guides/resource-routes) `/healthcheck` was making a `HEAD /` request to test that the page is able to load. This was having some negative side effects:

- We were getting a lot of extra `HEAD` and `GET` requests in our logs
- Trying to access `/healthcheck` from outside a development docker container returned 500s
- Once we started creating database records for loading `/`, the healthcheck started to create a new db record each time:

```
Redirecting to baseUrl /gallatin/recertify
HEAD / 302 - - 10.347 ms
Generating fa40c28e-86ac-401c-8bf7-346f073c7415
Creating Submission record in database for fa40c28e-86ac-401c-8bf7-346f073c7415 and agency gallatin
HEAD /gallatin/recertify 200 - - 18.807 ms
GET /healthcheck 200 - - 57.973 ms
```

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

1. Run this branch locally (`npm run dev`)
2. Watch the remix logs
3. Go to `localhost:3000/healthcheck` in your browser
4. The logs should only say: `GET /healthcheck 200`
5. The logs should not generate any other entries

Do this again from inside the docker container:
1. `docker compose up -d --build && docker compose logs -f remix_dev`
2. Go to `localhost:3003/healthcheck`