### PR TITLE
[PRP-334] Add CORS policy to doc upload s3 bucket

### DIFF
--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -301,6 +301,18 @@ module "doc_upload" {
   admin_role_names  = [module.participant.task_role_name]
 }
 
+resource "aws_s3_bucket_cors_configuration" "doc_upload_cors" {
+  bucket = local.document_upload_s3_name
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = ["https://${var.participant_url}"]
+    expose_headers  = []
+    max_age_seconds = 3000
+  }
+}
+
 module "side_load" {
   source           = "../../modules/s3-encrypted"
   environment_name = var.environment_name


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-334

## Changes
> What was added, updated, or removed in this PR.

- Add CORS policy to doc upload s3 bucket

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Because we are re-architecting doc upload to upload documents on the client-side in https://wicmtdp.atlassian.net/browse/PRP-332, we need to update our s3 bucket CORS policy to allow the participant site to PUT files into the S3 bucket

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

This terraform change has been applied to the dev environment and the WIP for #89 has also been deployed to the dev environment. A successful upload looks like this:

<img width="779" alt="Screenshot 2023-05-03 at 8 58 48 PM" src="https://user-images.githubusercontent.com/67701/236109899-5b0241fa-8611-4a92-abbb-bd48fa1975bb.png">

Test by:
1. Walking through the PRP until you get to upload in the dev environment
2. Upload a file
3. The file preview should work
4. [Bonus] Check that the file has been uploaded to the dev s3 bucket
