### PR TITLE
[Pilot] Patch Analytics

### DIFF
--- a/participant/app/root.tsx
+++ b/participant/app/root.tsx
@@ -59,7 +59,13 @@ export function links() {
   ];
 }
 
-type LoaderData = { locale: string; demoMode: string; missingData: string, MATOMO_SECURE: boolean, MATOMO_URL_BASE: string };
+type LoaderData = {
+  locale: string;
+  demoMode: string;
+  missingData: string;
+  MATOMO_SECURE: boolean;
+  MATOMO_URL_BASE: string;
+};
 
 export const loader: LoaderFunction = async ({ request, params }) => {
   const redirectTarget = await validRoute(request, params);
@@ -81,7 +87,13 @@ export const loader: LoaderFunction = async ({ request, params }) => {
 
   const missingData =
     url.searchParams.get("missing-data") == "true" ? "true" : "false";
-  return json<LoaderData>({ locale, demoMode, missingData, MATOMO_SECURE, MATOMO_URL_BASE });
+  return json<LoaderData>({
+    locale,
+    demoMode,
+    missingData,
+    MATOMO_SECURE,
+    MATOMO_URL_BASE,
+  });
 };
 
 export const handle = {
@@ -94,7 +106,8 @@ export const handle = {
 
 export default function App() {
   // Get the locale from the loader
-  const { locale, demoMode, missingData, MATOMO_SECURE, MATOMO_URL_BASE } = useLoaderData<LoaderData>();
+  const { locale, demoMode, missingData, MATOMO_SECURE, MATOMO_URL_BASE } =
+    useLoaderData<LoaderData>();
   const { i18n } = useTranslation();
 
   // This hook will change the i18n instance language to the current locale

--- a/participant/app/root.tsx
+++ b/participant/app/root.tsx
@@ -119,7 +119,7 @@ export default function App() {
   const isHydrated = useHydrated();
   if (isHydrated && MATOMO_URL_BASE) {
     const tracker = new MatomoTracker({
-      urlBase: MATOMO_URL_BASE,
+      urlBase: `http://${MATOMO_URL_BASE}`,
       siteId: 1,
       disabled: false, // optional, false by default. Makes all tracking calls no-ops if set to true.
       heartBeat: {
@@ -148,7 +148,6 @@ export default function App() {
       <head>
         <Meta />
         <Links />
-        <img src="//${MATOMO_URL_BASE}/matomo.php?idsite=1&amp;rec=1" />
       </head>
       <body>
         <Layout demoMode={demoMode} missingData={missingData}>
@@ -157,6 +156,7 @@ export default function App() {
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
+        <img referrerPolicy="no-referrer-when-downgrade" src={`http://${MATOMO_URL_BASE}/matomo.php?idsite=1&amp;rec=1`} alt="" />
       </body>
     </html>
   );

--- a/participant/app/root.tsx
+++ b/participant/app/root.tsx
@@ -156,7 +156,11 @@ export default function App() {
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
-        <img referrerPolicy="no-referrer-when-downgrade" src={`http://${MATOMO_URL_BASE}/matomo.php?idsite=1&amp;rec=1`} alt="" />
+        <img
+          referrerPolicy="no-referrer-when-downgrade"
+          src={`http://${MATOMO_URL_BASE}/matomo.php?idsite=1&amp;rec=1`}
+          alt=""
+        />
       </body>
     </html>
   );

--- a/participant/app/root.tsx
+++ b/participant/app/root.tsx
@@ -59,7 +59,7 @@ export function links() {
   ];
 }
 
-type LoaderData = { locale: string; demoMode: string; missingData: string };
+type LoaderData = { locale: string; demoMode: string; missingData: string, MATOMO_SECURE: boolean, MATOMO_URL_BASE: string };
 
 export const loader: LoaderFunction = async ({ request, params }) => {
   const redirectTarget = await validRoute(request, params);
@@ -81,7 +81,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
 
   const missingData =
     url.searchParams.get("missing-data") == "true" ? "true" : "false";
-  return json<LoaderData>({ locale, demoMode, missingData });
+  return json<LoaderData>({ locale, demoMode, missingData, MATOMO_SECURE, MATOMO_URL_BASE });
 };
 
 export const handle = {
@@ -94,7 +94,7 @@ export const handle = {
 
 export default function App() {
   // Get the locale from the loader
-  const { locale, demoMode, missingData } = useLoaderData<LoaderData>();
+  const { locale, demoMode, missingData, MATOMO_SECURE, MATOMO_URL_BASE } = useLoaderData<LoaderData>();
   const { i18n } = useTranslation();
 
   // This hook will change the i18n instance language to the current locale
@@ -122,6 +122,8 @@ export default function App() {
         setSecureCookie: MATOMO_SECURE,
         setRequestMethod: "POST",
         trackPageView: true,
+        setVisitorCookieTimeout: 1800,
+        setReferralCookieTimeout: 1800,
       },
     });
 
@@ -133,6 +135,7 @@ export default function App() {
       <head>
         <Meta />
         <Links />
+        <img src="//${MATOMO_URL_BASE}/matomo.php?idsite=1&amp;rec=1" />
       </head>
       <body>
         <Layout demoMode={demoMode} missingData={missingData}>

--- a/participant/app/root.tsx
+++ b/participant/app/root.tsx
@@ -119,7 +119,7 @@ export default function App() {
   const isHydrated = useHydrated();
   if (isHydrated && MATOMO_URL_BASE) {
     const tracker = new MatomoTracker({
-      urlBase: `http://${MATOMO_URL_BASE}`,
+      urlBase: `//${MATOMO_URL_BASE}`,
       siteId: 1,
       disabled: false, // optional, false by default. Makes all tracking calls no-ops if set to true.
       heartBeat: {
@@ -156,11 +156,13 @@ export default function App() {
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
-        <img
-          referrerPolicy="no-referrer-when-downgrade"
-          src={`http://${MATOMO_URL_BASE}/matomo.php?idsite=1&amp;rec=1`}
-          alt=""
-        />
+        <noscript>
+          <img
+            referrerPolicy="no-referrer-when-downgrade"
+            src={`//${MATOMO_URL_BASE}/matomo.php?idsite=1&rec=1`}
+            alt=""
+          />
+        </noscript>
       </body>
     </html>
   );

--- a/participant/docker-compose.yml
+++ b/participant/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       AWS_SECRET_ACCESS_KEY: "incredible_local_secret_phrase"
       MAX_UPLOAD_FILECOUNT: 5
       MAX_UPLOAD_SIZE_BYTES: 5242880
-      MATOMO_URL_BASE: "http://localhost:8080/"
+      MATOMO_URL_BASE: "localhost:8080"
       LOG_LEVEL: debug
     init: true
     ports:
@@ -59,7 +59,7 @@ services:
       S3_ENDPOINT_URL: http://s3-local:9000
       AWS_ACCESS_KEY_ID: "e2e_minio"
       AWS_SECRET_ACCESS_KEY: "incredible_local_secret_phrase"
-      MATOMO_URL_BASE: "http://localhost:8080/"
+      MATOMO_URL_BASE: "localhost:8080"
       LOG_LEVEL: warn
     init: true
     ports:


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-338

## Changes
* use `img_tag` code snippet to track analytics

## Context for reviewers
> The server isn't able to access the `MATOMO_SECURE` and `MATOMO_URL_BASE` variables, which prevents data tracking.

## Testing
1. Checkout this branch and run `docker compose up -d` for both the participant portal and the analytics application
2. Go through the application locally
3. Check the local analytics dashboard for your activity

Local test output
<img width="1148" alt="Screen Shot 2023-05-08 at 2 38 19 PM" src="https://user-images.githubusercontent.com/37313082/236904518-4293949d-b784-4288-91c1-32622bb025e9.png">

