### PR TITLE
[PRP-341] Add temporary js required message

### DIFF
--- a/participant/public/locales/en/common.json
+++ b/participant/public/locales/en/common.json
@@ -154,7 +154,7 @@
     "fileTypeError": "This is not a valid file type.",
     "fileSizeError": "This file is over the maximum size",
     "fileCountError": "You have reached the maximum number of files; please remove files before adding additional files",
-    "noScriptMessage": "File previews will not work with JavaScript disabled, but you may still upload files"
+    "noScriptMessage": "Please enable JavaScript to continue"
   },
   "Relationship": {
     "label": "Relationship to you",


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-341

## Changes
> What was added, updated, or removed in this PR.

- Update `<noscript>` message that is shown on `/upload` if a user does not have javascript enabled

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

1. Pull this branch
2. Run the participant container
3. Walk through the form until you get to the `/upload` page
4. You should see the following message

<img width="621" alt="Screenshot 2023-05-09 at 1 16 01 PM" src="https://github.com/navapbc/wic-participant-recertification-portal/assets/67701/81aef8ee-46e9-4135-8491-5f9f58ae81d3">


