### PR TITLE
[PRP-344] [Hotfix] to refresh s3 presigned urls even more frequently.

### DIFF
--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -349,7 +349,7 @@ module "refresh_s3_presigned_urls" {
   container_task_override = "{\"containerOverrides\": [{\"name\": \"${local.participant_service_name}\", \"command\": [\"npm\", \"run\", \"refresh-s3-urls\"]}]}"
   security_group_ids      = [module.participant.app_security_group.id]
   subnet_ids              = data.aws_subnets.default.ids
-  schedule_expression     = "cron(0 */3 * * ? *)"
+  schedule_expression     = "cron(0 * * * ? *)"
   schedule_enabled        = true
 }
 

--- a/infra/app/env-template/variables.tf
+++ b/infra/app/env-template/variables.tf
@@ -48,7 +48,7 @@ variable "participant_s3_presigned_url_expiration" {
 variable "participant_s3_presigned_url_renewal_threshold" {
   type        = string
   description = "The number of seconds a presigned s3 url is active before it is renewed"
-  default     = 7 * 60 * 60 # 25200 seconds = 7 hours
+  default     = 90 * 60 # 5400 seconds = 90 minutes
 }
 
 variable "participant_enable_exec" {


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-344

## Changes
> What was added, updated, or removed in this PR.

- Increased frequency of s3 presigned url check to once an hour
- Changed s3 presigned urls to be refreshed if not updated in the last 90m

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

The previous refresh schedule still results in some expired urls.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
