### PR TITLE
[PRP-339] Adding required tag to TextField, ChoiceInputGroup, and ele…

### DIFF
--- a/participant/app/components/AdjunctiveInput.tsx
+++ b/participant/app/components/AdjunctiveInput.tsx
@@ -15,10 +15,11 @@ export type AdjunctiveInputProps = Omit<
   adjunctiveKey: i18nKey;
   keyBase: string;
   values?: "yes" | "no";
+  required?: boolean;
 };
 
 export const AdjunctiveInput = (props: AdjunctiveInputProps): ReactElement => {
-  const { name, adjunctiveKey, legendStyle, values, ...rest } = props;
+  const { name, adjunctiveKey, legendStyle, values, required, ...rest } = props;
   const adjunctiveChoices: Choice[] = [
     {
       value: "yes",
@@ -42,6 +43,7 @@ export const AdjunctiveInput = (props: AdjunctiveInputProps): ReactElement => {
       legendKey={`${adjunctiveKey}.label`}
       legendStyle={legendStyle}
       helpElement={helpElement}
+      required={required}
       {...rest}
     />
   );

--- a/participant/app/components/ChoiceGroupInput.tsx
+++ b/participant/app/components/ChoiceGroupInput.tsx
@@ -66,6 +66,7 @@ export const ChoiceGroupInput = (
           <InputTypeClass
             key={`${keyBase}-${choice.value}`}
             defaultChecked={choice.selected}
+            required={required}
             {...getInputProps({
               id: `${keyBase}-${choice.value}`,
               label: choice.labelElement,

--- a/participant/app/components/DateInput.tsx
+++ b/participant/app/components/DateInput.tsx
@@ -67,6 +67,8 @@ export const DateInput = (props: DateInputProps): ReactElement => {
           size={maxLength}
           inputType="text"
           type="input"
+          required={required}
+          requiredStar={false}
           defaultValue={values && values[field]?.toString()}
         />
       </FormGroup>

--- a/participant/app/components/RelationshipInput.tsx
+++ b/participant/app/components/RelationshipInput.tsx
@@ -27,5 +27,12 @@ export const RelationshipInput = (
     labelElement: <Trans i18nKey={`${relationshipKey}.${relationship}`} />,
     selected: values && values == relationship,
   }));
-  return <ChoiceGroupInput choices={choices} type="radio" required={required} {...rest} />;
+  return (
+    <ChoiceGroupInput
+      choices={choices}
+      type="radio"
+      required={required}
+      {...rest}
+    />
+  );
 };

--- a/participant/app/components/RelationshipInput.tsx
+++ b/participant/app/components/RelationshipInput.tsx
@@ -14,17 +14,18 @@ export type RelationshipInputProps = Omit<
   relationshipKey: i18nKey;
   keyBase: string;
   values?: RelationshipType;
+  required?: boolean;
 };
 
 export const RelationshipInput = (
   props: RelationshipInputProps
 ): ReactElement => {
-  const { relationshipKey, values, ...rest } = props;
+  const { relationshipKey, values, required, ...rest } = props;
   const relationships = ["self", "child", "grandchild", "foster", "other"];
   const choices: Choice[] = relationships.map((relationship) => ({
     value: relationship,
     labelElement: <Trans i18nKey={`${relationshipKey}.${relationship}`} />,
     selected: values && values == relationship,
   }));
-  return <ChoiceGroupInput choices={choices} type="radio" {...rest} />;
+  return <ChoiceGroupInput choices={choices} type="radio" required={required} {...rest} />;
 };

--- a/participant/app/components/TextField.tsx
+++ b/participant/app/components/TextField.tsx
@@ -21,15 +21,16 @@ export type TextFieldProps = {
   labelClassName?: string;
   hint?: ReactElement;
   required?: boolean;
+  requiredStar?: boolean;
   type?: "input" | "textarea";
   inputType:
-    | "number"
-    | "search"
-    | "text"
-    | "email"
-    | "password"
-    | "tel"
-    | "url";
+  | "number"
+  | "search"
+  | "text"
+  | "email"
+  | "password"
+  | "tel"
+  | "url";
   defaultValue?: string;
   value?: string;
   className?: string;
@@ -45,6 +46,7 @@ export const TextField = (props: TextFieldProps): ReactElement => {
     labelClassName,
     hint,
     required,
+    requiredStar = required,
     type,
     inputType,
     defaultValue,
@@ -65,13 +67,14 @@ export const TextField = (props: TextFieldProps): ReactElement => {
     <>
       <Label htmlFor={id} className={labelClassName} hint={hint}>
         <Trans i18nKey={labelKey} />
-        {required && <Required />}
+        {requiredStar && <Required />}
       </Label>
       {error && <ErrorMessage id={`${id}-error-message`}>{error}</ErrorMessage>}
       <TextTypeClass
         onChange={handleChange}
         defaultValue={defaultValue}
         size={size}
+        required={required}
         {...errorProp}
         {...getInputProps({
           id: id,

--- a/participant/app/components/TextField.tsx
+++ b/participant/app/components/TextField.tsx
@@ -24,13 +24,13 @@ export type TextFieldProps = {
   requiredStar?: boolean;
   type?: "input" | "textarea";
   inputType:
-  | "number"
-  | "search"
-  | "text"
-  | "email"
-  | "password"
-  | "tel"
-  | "url";
+    | "number"
+    | "search"
+    | "text"
+    | "email"
+    | "password"
+    | "tel"
+    | "url";
   defaultValue?: string;
   value?: string;
   className?: string;

--- a/participant/tests/components/AdjunctiveInput.test.tsx
+++ b/participant/tests/components/AdjunctiveInput.test.tsx
@@ -39,6 +39,10 @@ it("should match display required marker if required is true", () => {
   renderWithRouter(<AdjunctiveInput {...testProps} required={true} />);
   const required = screen.getByText("*");
   expect(required).toBeInTheDocument;
-  expect(screen.getByRole("radio", { name: "Yes" }).getAttribute("required")).toBe("");
-  expect(screen.getByRole("radio", { name: "No" }).getAttribute("required")).toBe("");
+  expect(
+    screen.getByRole("radio", { name: "Yes" }).getAttribute("required")
+  ).toBe("");
+  expect(
+    screen.getByRole("radio", { name: "No" }).getAttribute("required")
+  ).toBe("");
 });

--- a/participant/tests/components/AdjunctiveInput.test.tsx
+++ b/participant/tests/components/AdjunctiveInput.test.tsx
@@ -39,4 +39,6 @@ it("should match display required marker if required is true", () => {
   renderWithRouter(<AdjunctiveInput {...testProps} required={true} />);
   const required = screen.getByText("*");
   expect(required).toBeInTheDocument;
+  expect(screen.getByRole("radio", { name: "Yes" }).getAttribute("required")).toBe("");
+  expect(screen.getByRole("radio", { name: "No" }).getAttribute("required")).toBe("");
 });

--- a/participant/tests/components/ChoiceGroupInput.test.tsx
+++ b/participant/tests/components/ChoiceGroupInput.test.tsx
@@ -18,6 +18,7 @@ const choices: Choice[] = ["a", "b", "c"].map((option) => {
   return {
     value: option,
     labelElement: <div>label {option}</div>,
+    testId: `choice-${option}`
   };
 });
 
@@ -49,6 +50,12 @@ it("should match display required marker if required is true", () => {
   );
   const required = screen.getByText("*");
   expect(required).toBeInTheDocument;
+  const choiceA = screen.getByRole('checkbox', { name: 'label a' })
+  expect(choiceA.getAttribute("required")).toBe("")
+  const choiceB = screen.getByRole('checkbox', { name: 'label b' })
+  expect(choiceB.getAttribute("required")).toBe("")
+  const choiceC = screen.getByRole('checkbox', { name: 'label c' })
+  expect(choiceC.getAttribute("required")).toBe("")
 });
 
 it("should display an helpElement if passed as props", () => {

--- a/participant/tests/components/ChoiceGroupInput.test.tsx
+++ b/participant/tests/components/ChoiceGroupInput.test.tsx
@@ -18,7 +18,7 @@ const choices: Choice[] = ["a", "b", "c"].map((option) => {
   return {
     value: option,
     labelElement: <div>label {option}</div>,
-    testId: `choice-${option}`
+    testId: `choice-${option}`,
   };
 });
 
@@ -50,12 +50,12 @@ it("should match display required marker if required is true", () => {
   );
   const required = screen.getByText("*");
   expect(required).toBeInTheDocument;
-  const choiceA = screen.getByRole('checkbox', { name: 'label a' })
-  expect(choiceA.getAttribute("required")).toBe("")
-  const choiceB = screen.getByRole('checkbox', { name: 'label b' })
-  expect(choiceB.getAttribute("required")).toBe("")
-  const choiceC = screen.getByRole('checkbox', { name: 'label c' })
-  expect(choiceC.getAttribute("required")).toBe("")
+  const choiceA = screen.getByRole("checkbox", { name: "label a" });
+  expect(choiceA.getAttribute("required")).toBe("");
+  const choiceB = screen.getByRole("checkbox", { name: "label b" });
+  expect(choiceB.getAttribute("required")).toBe("");
+  const choiceC = screen.getByRole("checkbox", { name: "label c" });
+  expect(choiceC.getAttribute("required")).toBe("");
 });
 
 it("should display an helpElement if passed as props", () => {

--- a/participant/tests/components/DateInput.test.tsx
+++ b/participant/tests/components/DateInput.test.tsx
@@ -52,3 +52,11 @@ it("renders date component with DMY hint", () => {
   const hint = screen.getByText("For Example: 28 4 1986");
   expect(hint).toBeInTheDocument;
 });
+
+it("renders the date component with required", () => {
+  renderWithRouter(<DateInput {...defaultProps} required={true} />);
+  const inputBoxes = screen.getAllByRole("textbox");
+  expect(inputBoxes[0].getAttribute("required")).toBe("");
+  expect(inputBoxes[1].getAttribute("required")).toBe("");
+  expect(inputBoxes[2].getAttribute("required")).toBe("");
+});

--- a/participant/tests/components/NameInput.test.tsx
+++ b/participant/tests/components/NameInput.test.tsx
@@ -38,3 +38,11 @@ it("renders without legal hint", () => {
   const lastName = screen.getByRole("textbox", { name: "Last name *" });
   expect(lastName).toBeInTheDocument;
 });
+
+it("renders with required tags", () => {
+  renderWithRouter(<NameInput {...defaultProps} legal={false} />);
+  const firstName = screen.getByRole("textbox", { name: "First name *" });
+  expect(firstName.getAttribute("required")).toBe("");
+  const lastName = screen.getByRole("textbox", { name: "Last name *" });
+  expect(lastName.getAttribute("required")).toBe("");
+});

--- a/participant/tests/components/RelationshipInput.test.tsx
+++ b/participant/tests/components/RelationshipInput.test.tsx
@@ -47,4 +47,10 @@ it("should match display required marker if required is true", () => {
   renderWithRouter(<RelationshipInput {...testProps} required={true} />);
   const required = screen.getByText("*");
   expect(required).toBeInTheDocument;
+  const radioButtons = screen.getAllByRole("radio");
+  expect(radioButtons[0].getAttribute("required")).toBe("");
+  expect(radioButtons[1].getAttribute("required")).toBe("");
+  expect(radioButtons[2].getAttribute("required")).toBe("");
+  expect(radioButtons[3].getAttribute("required")).toBe("");
+  expect(radioButtons[4].getAttribute("required")).toBe("");
 });

--- a/participant/tests/components/TextField.test.tsx
+++ b/participant/tests/components/TextField.test.tsx
@@ -19,7 +19,7 @@ const testProps: TextFieldProps = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   handleChange: (
     e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>
-  ) => {},
+  ) => { },
 };
 
 it("should match snapshot when it is a textfield", () => {
@@ -46,6 +46,8 @@ it("should match display required marker if required is true", () => {
   renderWithRouter(<TextField {...testProps} required={true} />);
   const required = screen.getByText("*");
   expect(required).toBeInTheDocument;
+  const textbox = screen.getByRole("textbox")
+  expect(textbox.getAttribute("required")).toBe("")
 });
 
 it("should display the value when it is a textfield", () => {

--- a/participant/tests/components/TextField.test.tsx
+++ b/participant/tests/components/TextField.test.tsx
@@ -19,7 +19,7 @@ const testProps: TextFieldProps = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   handleChange: (
     e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>
-  ) => { },
+  ) => {},
 };
 
 it("should match snapshot when it is a textfield", () => {
@@ -46,8 +46,8 @@ it("should match display required marker if required is true", () => {
   renderWithRouter(<TextField {...testProps} required={true} />);
   const required = screen.getByText("*");
   expect(required).toBeInTheDocument;
-  const textbox = screen.getByRole("textbox")
-  expect(textbox.getAttribute("required")).toBe("")
+  const textbox = screen.getByRole("textbox");
+  expect(textbox.getAttribute("required")).toBe("");
 });
 
 it("should display the value when it is a textfield", () => {

--- a/participant/tests/components/__snapshots__/NameInput.test.tsx.snap
+++ b/participant/tests/components/__snapshots__/NameInput.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`renders name input component 1`] = `
       data-testid="textInput"
       id="input-example.firstName"
       name="input-example.firstName"
+      required=""
       type="text"
       value=""
     />
@@ -62,6 +63,7 @@ exports[`renders name input component 1`] = `
       data-testid="textInput"
       id="input-example.lastName"
       name="input-example.lastName"
+      required=""
       type="text"
       value=""
     />


### PR DESCRIPTION
…ments containing them. Updated jest tests

## Ticket

https://wicmtdp.atlassian.net/browse/PRP-339

## Changes
> Required tag added to components
* TextField
* ChoiceGroupInput
* AdjunctiveInput
* DateInput
* NameInput
* RelationshipInput
> Tests updated or added to check for tag

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

## Testing
Inspect an element that should have the required element. See the `required=""` in the `<input>` component
![required-prp-339](https://github.com/navapbc/wic-participant-recertification-portal/assets/723391/f906df4a-4294-4bf1-8e22-32a8a7a02352)
