### PR TITLE
[PRP-344] Create IAM user for longer S3 presigned url expiration time

### DIFF
--- a/bin/manually-refresh-urls.sh
+++ b/bin/manually-refresh-urls.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This script refreshes the S3 presigned urls saved to the participant database.
+# Example: ./manually-refresh-urls dev 30
+set -euo pipefail
+
+# Positional arguments.
+# The environment in which to refresh urls.
+ENV_NAME=$1
+# The renewal threshold in seconds. If a presigned url is older than this many seconds, it is renewed.
+RENEWAL_THRESHOLD=$2
+
+CLUSTER_NAME="wic-prp-app-${ENV_NAME}"
+SERVICE_NAME="wic-prp-participant-${ENV_NAME}"
+TASK_DEFINITION_NAME="wic-prp-participant-${ENV_NAME}"
+CONTAINER_NAME="wic-prp-participant-${ENV_NAME}"
+
+NETWORK_CONFIG=$(aws ecs describe-services --cluster $CLUSTER_NAME --service $SERVICE_NAME | jq -r '.services[0].networkConfiguration')
+
+CONTAINER_OVERRIDES="{ \"containerOverrides\": [{ \"name\": \"${CONTAINER_NAME}\", \"command\": [\"npm\", \"run\", \"refresh-s3-urls\"], \"environment\" : [{ \"name\": \"S3_PRESIGNED_URL_RENEWAL_THRESHOLD\", \"value\": \"${RENEWAL_THRESHOLD}\" }]}]}"
+
+aws ecs run-task \
+  --cluster $CLUSTER_NAME \
+  --task-definition $TASK_DEFINITION_NAME \
+  --overrides "${CONTAINER_OVERRIDES}" \
+  --network-configuration "${NETWORK_CONFIG}" \
+  --launch-type="FARGATE" \
+  --platform-version="1.4.0"

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -330,7 +330,6 @@ module "doc_upload" {
   read_role_names   = [module.participant.task_role_name, module.staff.task_role_name]
   write_role_names  = [module.participant.task_role_name]
   delete_role_names = [module.participant.task_role_name]
-  admin_role_names  = [module.participant.task_role_name]
 }
 
 resource "aws_s3_bucket_cors_configuration" "doc_upload_cors" {
@@ -361,7 +360,6 @@ module "side_load" {
   source           = "../../modules/s3-encrypted"
   s3_bucket_name   = local.side_load_s3_name
   read_role_names  = [module.participant.task_role_name]
-  admin_role_names = [module.participant.task_role_name]
 }
 
 # todo: cleanup service names

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -57,6 +57,8 @@ data "aws_subnets" "default" {
 ############################################################################################
 
 module "s3_machine_user" {
+  # checkov:skip=CKV_AWS_273:Explicitly using an IAM user for longer S3 presigned url expiration times
+
   source            = "../../modules/iam-machine-user"
   machine_user_name = local.document_upload_s3_name
 }

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -1,18 +1,17 @@
-# TODO(https://github.com/navapbc/template-infra/issues/152) use non-default VPC
-data "aws_vpc" "default" {
-  default = true
-}
-
-# TODO(https://github.com/navapbc/template-infra/issues/152) use private subnets
-data "aws_subnets" "default" {
-  filter {
-    name   = "default-for-az"
-    values = [true]
-  }
-}
+############################################################################################
+## The root module used to manage all per-environment resources
+############################################################################################
 
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+
+module "project_config" {
+  source = "../../project-config"
+}
+
+module "app_config" {
+  source = "../app-config"
+}
 
 locals {
   project_name                            = module.project_config.project_name
@@ -32,34 +31,84 @@ locals {
   waf_name                                = "${local.project_name}-${local.project_name}-waf"
 }
 
-module "project_config" {
-  source = "../../project-config"
+############################################################################################
+## VPC
+## - Currently uses the default VPC
+############################################################################################
+
+# TODO(https://github.com/navapbc/template-infra/issues/152) use non-default VPC
+data "aws_vpc" "default" {
+  default = true
 }
+
+# TODO(https://github.com/navapbc/template-infra/issues/152) use private subnets
+data "aws_subnets" "default" {
+  filter {
+    name   = "default-for-az"
+    values = [true]
+  }
+}
+
+############################################################################################
+## Document upload
+## - Creates an IAM user to pass to the AWS SDK in the participant app for S3 operations
+## - Creates an S3 bucket
+## - Sets CORS policy for the document upload S3 bucket
+############################################################################################
+
+module "s3_machine_user" {
+  source            = "../../modules/iam-machine-user"
+  machine_user_name = local.document_upload_s3_name
+}
+
+module "doc_upload" {
+  source             = "../../modules/s3-encrypted"
+  s3_bucket_name     = local.document_upload_s3_name
+  log_target_prefix  = var.environment_name
+  read_group_names   = [module.s3_machine_user.machine_user_group.name]
+  write_group_names  = [module.s3_machine_user.machine_user_group.name]
+  delete_group_names = [module.s3_machine_user.machine_user_group.name]
+}
+
+resource "aws_s3_bucket_cors_configuration" "doc_upload_cors" {
+  bucket = local.document_upload_s3_name
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = ["https://${var.participant_url}"]
+    expose_headers  = []
+    max_age_seconds = 3000
+  }
+}
+
+############################################################################################
+## ECS service cluster
+## - Contains services for the participant, staff, and analytics applications
+############################################################################################
+
+module "service_cluster" {
+  source       = "../../modules/service-cluster"
+  cluster_name = local.cluster_name
+}
+
+############################################################################################
+## The participant application
+## - Creates an RDS Aurora postgresql database
+## - Creates an ECS service and task for the Remix application
+## - Sets autoscaling for the ECS service
+## - Creates an Eventbridge schedule to update S3 presigned urls saved to the database
+##   so that they don't expire and become inaccessible
+## - Creates an S3 bucket to side load data, such as staff users, into the database
+############################################################################################
 
 data "aws_ecr_repository" "participant_image_repository" {
   name = "${local.project_name}-participant"
 }
 
-data "aws_ecr_repository" "staff_image_repository" {
-  name = "${local.project_name}-staff"
-}
-
-data "aws_ecr_repository" "analytics_image_repository" {
-  name = "${local.project_name}-analytics"
-}
-
-module "app_config" {
-  source = "../app-config"
-}
-
 module "participant_database" {
   source        = "../../modules/database"
   database_name = local.participant_database_name
-}
-
-module "service_cluster" {
-  source       = "../../modules/service-cluster"
-  cluster_name = local.cluster_name
 }
 
 module "participant" {
@@ -165,6 +214,36 @@ module "participant_autoscale" {
   ecs_task_executor_role_name = "${local.participant_service_name}-task-executor"
 }
 
+module "refresh_s3_presigned_urls" {
+  source                  = "../../modules/task-scheduled"
+  schedule_name           = local.refresh_s3_presigned_urls_schedule_name
+  cluster_name            = local.cluster_name
+  task_definition_family  = local.participant_service_name
+  container_task_override = "{\"containerOverrides\": [{\"name\": \"${local.participant_service_name}\", \"command\": [\"npm\", \"run\", \"refresh-s3-urls\"]}]}"
+  security_group_ids      = [module.participant.app_security_group.id]
+  subnet_ids              = data.aws_subnets.default.ids
+  schedule_expression     = "cron(0 * * * ? *)"
+  schedule_enabled        = true
+}
+
+module "side_load" {
+  source            = "../../modules/s3-encrypted"
+  s3_bucket_name    = local.side_load_s3_name
+  log_target_prefix = var.environment_name
+  read_group_names  = [module.s3_machine_user.machine_user_group.name]
+}
+
+############################################################################################
+## The staff application
+## - Creates a Cognito user pool and client
+## - Creates a JWT secret required by the staff application
+## - Creates an ECS service and task for the Lowdefy application
+############################################################################################
+
+data "aws_ecr_repository" "staff_image_repository" {
+  name = "${local.project_name}-staff"
+}
+
 data "aws_ses_domain_identity" "verified_domain" {
   domain = "wic-services.org"
 }
@@ -249,6 +328,17 @@ module "staff" {
   ]
 }
 
+############################################################################################
+## The analytics application
+## - Creates an RDS Aurora mysql database
+## - Creates an EFS for persistent container data
+## - Creates an ECS service and task for the Matomo application
+############################################################################################
+
+data "aws_ecr_repository" "analytics_image_repository" {
+  name = "${local.project_name}-analytics"
+}
+
 module "analytics_database" {
   source        = "../../modules/database"
   database_name = local.analytics_database_name
@@ -324,43 +414,9 @@ module "analytics" {
   ]
 }
 
-module "doc_upload" {
-  source            = "../../modules/s3-encrypted"
-  s3_bucket_name    = local.document_upload_s3_name
-  read_role_names   = [module.participant.task_role_name, module.staff.task_role_name]
-  write_role_names  = [module.participant.task_role_name]
-  delete_role_names = [module.participant.task_role_name]
-}
-
-resource "aws_s3_bucket_cors_configuration" "doc_upload_cors" {
-  bucket = local.document_upload_s3_name
-
-  cors_rule {
-    allowed_headers = ["*"]
-    allowed_methods = ["PUT"]
-    allowed_origins = ["https://${var.participant_url}"]
-    expose_headers  = []
-    max_age_seconds = 3000
-  }
-}
-
-module "refresh_s3_presigned_urls" {
-  source                  = "../../modules/task-scheduled"
-  schedule_name           = local.refresh_s3_presigned_urls_schedule_name
-  cluster_name            = local.cluster_name
-  task_definition_family  = local.participant_service_name
-  container_task_override = "{\"containerOverrides\": [{\"name\": \"${local.participant_service_name}\", \"command\": [\"npm\", \"run\", \"refresh-s3-urls\"]}]}"
-  security_group_ids      = [module.participant.app_security_group.id]
-  subnet_ids              = data.aws_subnets.default.ids
-  schedule_expression     = "cron(0 * * * ? *)"
-  schedule_enabled        = true
-}
-
-module "side_load" {
-  source           = "../../modules/s3-encrypted"
-  s3_bucket_name   = local.side_load_s3_name
-  read_role_names  = [module.participant.task_role_name]
-}
+############################################################################################
+## DNS for the participant, staff, and analytics applications
+############################################################################################
 
 # todo: cleanup service names
 module "dns" {

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -231,7 +231,7 @@ module "refresh_s3_presigned_urls" {
   container_task_override = "{\"containerOverrides\": [{\"name\": \"${local.participant_service_name}\", \"command\": [\"npm\", \"run\", \"refresh-s3-urls\"]}]}"
   security_group_ids      = [module.participant.app_security_group.id]
   subnet_ids              = data.aws_subnets.default.ids
-  schedule_expression     = "cron(0 * * * ? *)"
+  schedule_expression     = "cron(0 9 * * ? *)" # Run once a day at ~3am US time
   schedule_enabled        = true
 }
 

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -129,19 +129,18 @@ module "participant" {
   # The database seed needs longer lead time before healthchecks kick in to kill the container
   healthcheck_start_period = 120
   enable_exec              = var.participant_enable_exec
-  # @TODO: We shouldn't need to be doing quite so much string interpolation. Perhaps we can pass back the arns instead of the secret_names.
   container_secrets = [
     {
       name      = "DATABASE_URL",
-      valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${module.participant_database.admin_db_url_secret_name}"
+      valueFrom = module.participant_database.admin_db_url_secret_arn,
     },
     {
       name      = "POSTGRES_PASSWORD",
-      valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${module.participant_database.admin_password_secret_name}"
+      valueFrom = module.participant_database.admin_password_secret_arn,
     },
     {
       name      = "POSTGRES_USER",
-      valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${module.participant_database.admin_user_secret_name}"
+      valueFrom = module.participant_database.admin_user_secret_arn,
     }
   ]
   container_env_vars = [
@@ -191,9 +190,9 @@ module "participant" {
     }
   ]
   service_ssm_resource_paths = [
-    module.participant_database.admin_db_url_secret_name,
-    module.participant_database.admin_password_secret_name,
-    module.participant_database.admin_user_secret_name,
+    module.participant_database.admin_db_url_secret_arn,
+    module.participant_database.admin_password_secret_arn,
+    module.participant_database.admin_user_secret_arn,
   ]
   container_bind_mounts = {
     "tmp" : {
@@ -294,15 +293,15 @@ module "staff" {
   container_secrets = [
     {
       name      = "LOWDEFY_SECRET_PG_CONNECTION_STRING",
-      valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${module.participant_database.admin_db_url_secret_name}",
+      valueFrom = module.participant_database.admin_db_url_secret_arn,
     },
     {
       name      = "LOWDEFY_SECRET_OPENID_CLIENT_ID",
-      valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${module.staff_idp.client_id_secret_name}",
+      valueFrom = module.staff_idp.client_id_secret_arn,
     },
     {
       name      = "LOWDEFY_SECRET_OPENID_CLIENT_SECRET",
-      valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${module.staff_idp.client_secret_secret_name}",
+      valueFrom = module.staff_idp.client_secret_secret_arn,
     },
     {
       name      = "LOWDEFY_SECRET_JWT_SECRET",
@@ -317,10 +316,10 @@ module "staff" {
 
   ]
   service_ssm_resource_paths = [
-    module.participant_database.admin_db_url_secret_name,
-    module.staff_idp.client_id_secret_name,
-    module.staff_idp.client_secret_secret_name,
-    aws_ssm_parameter.staff_jwt_secret.name,
+    module.participant_database.admin_db_url_secret_arn
+    module.staff_idp.client_id_secret_arn,
+    module.staff_idp.client_secret_secret_arn,
+    aws_ssm_parameter.staff_jwt_secret.arn,
   ]
   depends_on = [
     module.participant_database,
@@ -376,15 +375,15 @@ module "analytics" {
   container_secrets = [
     {
       name      = "MATOMO_DATABASE_HOST",
-      valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${module.analytics_database.admin_db_host_secret_name}"
+      valueFrom = module.analytics_database.admin_db_host_secret_arn,
     },
     {
       name      = "MATOMO_DATABASE_PASSWORD",
-      valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${module.analytics_database.admin_password_secret_name}"
+      valueFrom = module.analytics_database.admin_password_secret_arn,
     },
     {
       name      = "MATOMO_DATABASE_USERNAME",
-      valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${module.analytics_database.admin_user_secret_name}"
+      valueFrom = module.analytics_database.admin_user_secret_arn,
     }
   ]
   container_env_vars = [
@@ -394,9 +393,9 @@ module "analytics" {
     }
   ]
   service_ssm_resource_paths = [
-    module.analytics_database.admin_db_host_secret_name,
-    module.analytics_database.admin_password_secret_name,
-    module.analytics_database.admin_user_secret_name,
+    module.analytics_database.admin_db_host_secret_arn,
+    module.analytics_database.admin_password_secret_arn,
+    module.analytics_database.admin_user_secret_arn,
   ]
   container_efs_volumes = {
     "html" : {

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -141,7 +141,15 @@ module "participant" {
     {
       name      = "POSTGRES_USER",
       valueFrom = module.participant_database.admin_user_secret_arn,
-    }
+    },
+    {
+      name      = "AWS_ACCESS_KEY_ID",
+      valueFrom = module.s3_machine_user.access_key_id_secret_arn,
+    },
+    {
+      name      = "AWS_SECRET_ACCESS_KEY",
+      valueFrom = module.s3_machine_user.secret_access_key_secret_arn,
+    },
   ]
   container_env_vars = [
     {
@@ -193,6 +201,8 @@ module "participant" {
     module.participant_database.admin_db_url_secret_arn,
     module.participant_database.admin_password_secret_arn,
     module.participant_database.admin_user_secret_arn,
+    module.s3_machine_user.access_key_id_secret_arn,
+    module.s3_machine_user.secret_access_key_secret_arn,
   ]
   container_bind_mounts = {
     "tmp" : {

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -326,7 +326,7 @@ module "staff" {
 
   ]
   service_ssm_resource_paths = [
-    module.participant_database.admin_db_url_secret_arn
+    module.participant_database.admin_db_url_secret_arn,
     module.staff_idp.client_id_secret_arn,
     module.staff_idp.client_secret_secret_arn,
     aws_ssm_parameter.staff_jwt_secret.arn,

--- a/infra/app/env-template/variables.tf
+++ b/infra/app/env-template/variables.tf
@@ -47,8 +47,8 @@ variable "participant_s3_presigned_url_expiration" {
 
 variable "participant_s3_presigned_url_renewal_threshold" {
   type        = string
-  description = "The number of seconds a presigned s3 url is active before it is renewed"
-  default     = 90 * 60 # 5400 seconds = 90 minutes
+  description = "If a presigned url is older than this many seconds, it is renewed"
+  default     = 4 * 24 * 60 * 60 # 345600 seconds = 4 days
 }
 
 variable "participant_enable_exec" {

--- a/infra/modules/auth-github-actions/README.md
+++ b/infra/modules/auth-github-actions/README.md
@@ -4,7 +4,7 @@ This module sets up a way for GitHub Actions to access AWS resources using short
 
 1. Set up GitHub as an OpenID Connect Provider in the AWS account
 2. Create an IAM role that GitHub actions will assume
-3. Attach an IAM policy to the GitHub actions role that provides the necessary access to AWS account resources. By default this module will provide the [AWS managed Developer power user access policy `PowerUserAccess`](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html)
+3. Attach an IAM policy to the GitHub actions role that provides the necessary access to AWS account resources.
 
 ## Related Implementations
 

--- a/infra/modules/cognito-staff-user/create-staff-users.sh
+++ b/infra/modules/cognito-staff-user/create-staff-users.sh
@@ -5,7 +5,7 @@
 # - the path to a json file that maps local agencies and emails (which are used as the username).
 # See below for more details.
 # Example: ./create-staff-users dev /tmp/email.json
-# @TODO: This might possibly be better if this were pulled down from an S3 bucket.
+# @TODO: This might possibly be better if the list of user_emails were pulled down from an S3 bucket.
 set -euo pipefail
 
 # Positional arguments.

--- a/infra/modules/cognito/outputs.tf
+++ b/infra/modules/cognito/outputs.tf
@@ -2,10 +2,10 @@ output "user_pool_id" {
   value = aws_cognito_user_pool.pool.id
 }
 
-output "client_id_secret_name" {
-  value = local.client_id_secret_name
+output "client_id_secret_arn" {
+  value = aws_ssm_parameter.client_id.arn
 }
 
-output "client_secret_secret_name" {
-  value = local.client_secret_secret_name
+output "client_secret_secret_arn" {
+  value = aws_ssm_parameter.client_secret.arn
 }

--- a/infra/modules/database/outputs.tf
+++ b/infra/modules/database/outputs.tf
@@ -2,18 +2,18 @@ output "admin_user" {
   value = local.admin_user
 }
 
-output "admin_user_secret_name" {
-  value = local.admin_user_secret_name
+output "admin_user_secret_arn" {
+  value = aws_ssm_parameter.admin_user.arn
 }
 
-output "admin_password_secret_name" {
-  value = local.admin_password_secret_name
+output "admin_password_secret_arn" {
+  value = aws_ssm_parameter.admin_password.arn
 }
 
-output "admin_db_url_secret_name" {
-  value = local.admin_db_url_secret_name
+output "admin_db_url_secret_arn" {
+  value = aws_ssm_parameter.admin_db_url.arn
 }
 
-output "admin_db_host_secret_name" {
-  value = local.admin_db_host_secret_name
+output "admin_db_host_secret_arn" {
+  value = aws_ssm_parameter.admin_db_host.arn
 }

--- a/infra/modules/iam-machine-user/main.tf
+++ b/infra/modules/iam-machine-user/main.tf
@@ -1,0 +1,44 @@
+############################################################################################
+## A module for creating a machine IAM user
+## - Creates a group for the machine user to belong to
+## - Creates access keys for the machine user
+## - Saves the machine user's access keys to Systems Manager Parameter Store
+############################################################################################
+
+############################################################################################
+## IAM user and group
+############################################################################################
+
+resource "aws_iam_user" "machine_user" {
+  name = var.machine_user_name
+}
+
+resource "aws_iam_group" "machine_user" {
+  name = "${var.machine_user_name}-group"
+}
+
+resource "aws_iam_group_membership" "machine_user" {
+  name  = "${var.machine_user_name}-group-membership"
+  users = [aws_iam_user.machine_user.name]
+  group = aws_iam_group.machine_user.name
+}
+
+############################################################################################
+## Access key
+############################################################################################
+
+resource "aws_iam_access_key" "machine_user" {
+  user = aws_iam_user.machine_user.name
+}
+
+resource "aws_ssm_parameter" "access_key_id" {
+  name  = "${var.machine_user_name}-access-key-id"
+  type  = "SecureString"
+  value = aws_iam_access_key.machine_user.id
+}
+
+resource "aws_ssm_parameter" "secret_access_key" {
+  name  = "${var.machine_user_name}-secret-access-key"
+  type  = "SecureString"
+  value = aws_iam_access_key.machine_user.secret
+}

--- a/infra/modules/iam-machine-user/outputs.tf
+++ b/infra/modules/iam-machine-user/outputs.tf
@@ -2,10 +2,10 @@ output "machine_user_group" {
   value = aws_iam_group.machine_user
 }
 
-output "access_key_id_arn" {
+output "access_key_id_secret_arn" {
   value = aws_ssm_parameter.access_key_id.arn
 }
 
-output "secret_access_key_arn" {
+output "secret_access_key_secret_arn" {
   value = aws_ssm_parameter.secret_access_key.arn
 }

--- a/infra/modules/iam-machine-user/outputs.tf
+++ b/infra/modules/iam-machine-user/outputs.tf
@@ -1,0 +1,11 @@
+output "machine_user_group" {
+  value = aws_iam_group.machine_user
+}
+
+output "access_key_id_arn" {
+  value = aws_ssm_parameter.access_key_id.arn
+}
+
+output "secret_access_key_arn" {
+  value = aws_ssm_parameter.secret_access_key.arn
+}

--- a/infra/modules/iam-machine-user/variables.tf
+++ b/infra/modules/iam-machine-user/variables.tf
@@ -1,0 +1,4 @@
+variable "machine_user_name" {
+  type        = string
+  description = "The name of the machine user"
+}

--- a/infra/modules/s3-encrypted/main.tf
+++ b/infra/modules/s3-encrypted/main.tf
@@ -42,12 +42,6 @@ resource "aws_iam_policy" "delete" {
   policy      = data.aws_iam_policy_document.delete_s3.json
 }
 
-resource "aws_iam_policy" "admin" {
-  name        = "${var.s3_bucket_name}-admin"
-  description = "Allows admin access to the bucket"
-  policy      = data.aws_iam_policy_document.admin_s3.json
-}
-
 resource "aws_iam_role_policy_attachment" "read" {
   for_each   = toset(var.read_role_names)
   role       = each.value
@@ -64,12 +58,6 @@ resource "aws_iam_role_policy_attachment" "delete" {
   for_each   = toset(var.delete_role_names)
   role       = each.value
   policy_arn = aws_iam_policy.delete.arn
-}
-
-resource "aws_iam_role_policy_attachment" "admin" {
-  for_each   = toset(var.admin_role_names)
-  role       = each.value
-  policy_arn = aws_iam_policy.admin.arn
 }
 
 resource "aws_s3_bucket_versioning" "s3_encrypted" {
@@ -199,24 +187,6 @@ data "aws_iam_policy_document" "write_s3" {
     effect = "Allow"
     actions = [
       "s3:PutObject",
-      "kms:GenerateDataKey",
-      "kms:Decrypt",
-    ]
-
-    resources = [
-      aws_kms_key.s3_encrypted.arn,
-      aws_s3_bucket.s3_encrypted.arn,
-      "${aws_s3_bucket.s3_encrypted.arn}/*"
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "admin_s3" {
-  statement {
-    sid    = "AllowAdminAccess"
-    effect = "Allow"
-    actions = [
-      "s3:CreateBucket",
       "kms:GenerateDataKey",
       "kms:Decrypt",
     ]

--- a/infra/modules/s3-encrypted/main.tf
+++ b/infra/modules/s3-encrypted/main.tf
@@ -1,5 +1,31 @@
+############################################################################################
+## A module for creating an encrypted S3 bucket
+## - With associated S3 bucket policies and access management
+## - Also creates an encrypted S3 bucket for logging operations
+## - Creates IAM policies:
+##   - IAM policies in this module are broken out into read, write, and delete
+##     so that these permissions can be modularly assigned to different user groups by the
+##     module calling this one.
+############################################################################################
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+
+############################################################################################
+## KMS key
+############################################################################################
+
+resource "aws_kms_key" "s3_encrypted" {
+  description = "KMS key for encrypted S3 bucket"
+  # The waiting period, specified in number of days. After receiving a deletion request, AWS KMS will delete the KMS key after the waiting period ends. During the waiting period, the KMS key status and key state is Pending deletion. See https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html#deleting-keys-how-it-works
+  deletion_window_in_days = "10"
+  # Generates new cryptographic material every 365 days, this is used to encrypt your data. The KMS key retains the old material for decryption purposes.
+  enable_key_rotation = "true"
+}
+
+############################################################################################
+## Encrypted S3 bucket
+############################################################################################
 
 resource "aws_s3_bucket" "s3_encrypted" {
   bucket = var.s3_bucket_name
@@ -7,61 +33,11 @@ resource "aws_s3_bucket" "s3_encrypted" {
   # checkov:skip=CKV_AWS_144:Cross region replication not required by default
   # checkov:skip=CKV2_AWS_61:Lifecycle policy will be added in later ticket for post-pilot cleanup
   # checkov:skip=CKV2_AWS_62:Disable SNS requirement
-
-}
-
-resource "aws_s3_bucket_public_access_block" "s3_encrypted" {
-  bucket = aws_s3_bucket.s3_encrypted.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource "aws_s3_bucket_policy" "s3_encrypted" {
-  bucket = aws_s3_bucket.s3_encrypted.id
-  policy = data.aws_iam_policy_document.s3_encrypted.json
-}
-
-resource "aws_iam_policy" "read" {
-  name        = "${var.s3_bucket_name}-read"
-  description = "Allows read access to the bucket"
-  policy      = data.aws_iam_policy_document.read_s3.json
-}
-
-resource "aws_iam_policy" "write" {
-  name        = "${var.s3_bucket_name}-write"
-  description = "Allows write access to the bucket"
-  policy      = data.aws_iam_policy_document.write_s3.json
-}
-
-resource "aws_iam_policy" "delete" {
-  name        = "${var.s3_bucket_name}-delete"
-  description = "Allows delete access to the bucket"
-  policy      = data.aws_iam_policy_document.delete_s3.json
-}
-
-resource "aws_iam_role_policy_attachment" "read" {
-  for_each   = toset(var.read_role_names)
-  role       = each.value
-  policy_arn = aws_iam_policy.read.arn
-}
-
-resource "aws_iam_role_policy_attachment" "write" {
-  for_each   = toset(var.write_role_names)
-  role       = each.value
-  policy_arn = aws_iam_policy.write.arn
-}
-
-resource "aws_iam_role_policy_attachment" "delete" {
-  for_each   = toset(var.delete_role_names)
-  role       = each.value
-  policy_arn = aws_iam_policy.delete.arn
 }
 
 resource "aws_s3_bucket_versioning" "s3_encrypted" {
   bucket = aws_s3_bucket.s3_encrypted.id
+
   versioning_configuration {
     status = "Enabled"
   }
@@ -78,125 +54,18 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "s3_encrypted" {
   }
 }
 
-resource "aws_kms_key" "s3_encrypted" {
-  description = "KMS key for S3 buckets"
-  # The waiting period, specified in number of days. After receiving a deletion request, AWS KMS will delete the KMS key after the waiting period ends. During the waiting period, the KMS key status and key state is Pending deletion. See https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html#deleting-keys-how-it-works
-  deletion_window_in_days = "10"
-  # Generates new cryptographic material every 365 days, this is used to encrypt your data. The KMS key retains the old material for decryption purposes.
-  enable_key_rotation = "true"
-}
-
-# ----------------------------------------------------
-#
-#  Document Upload Logging
-#
-# ----------------------------------------------------
-
-# Create the S3 bucket to provide server access logging.
-resource "aws_s3_bucket" "s3_encrypted_log" {
-  bucket = "${var.s3_bucket_name}-logging"
-
-  # checkov:skip=CKV_AWS_144:Cross region replication not required by default
-  # checkov:skip=CKV2_AWS_61:Lifecycle policy will be added in later ticket for post-pilot cleanup
-  # checkov:skip=CKV2_AWS_62:Disable SNS requirement
-}
-resource "aws_s3_bucket_logging" "s3_encrypted_log" {
+resource "aws_s3_bucket_public_access_block" "s3_encrypted" {
   bucket = aws_s3_bucket.s3_encrypted.id
-  # Checkov recommends using an s3 bucket to store logging for other s3 buckets. The bucket created on #L61 is the target bucket
-  target_bucket = aws_s3_bucket.s3_encrypted_log.bucket
-  target_prefix = aws_s3_bucket.s3_encrypted.bucket
-}
-
-resource "aws_s3_bucket_versioning" "s3_encrypted_log" {
-  bucket = aws_s3_bucket.s3_encrypted_log.id
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "s3_encrypted_log" {
-  bucket = aws_s3_bucket.s3_encrypted_log.bucket
-
-  rule {
-    apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.s3_encrypted.arn
-      sse_algorithm     = "aws:kms"
-    }
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "s3_encrypted_log" {
-  bucket = aws_s3_bucket.s3_encrypted_log.id
 
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
-resource "aws_s3_bucket_policy" "s3_encrypted_log" {
-  bucket = aws_s3_bucket.s3_encrypted_log.id
-  policy = data.aws_iam_policy_document.s3_encrypted_log.json
-}
 
-# ----------------------------------------------------
-#
-#  Data Attributes
-#
-# ----------------------------------------------------
-
-data "aws_iam_policy_document" "delete_s3" {
-  statement {
-    sid    = "AllowDelete"
-    effect = "Allow"
-    actions = [
-      "s3:AbortMultipartUpload",
-      "s3:DeleteObject",
-      "kms:Decrypt",
-      "kms:GenerateDataKey",
-    ]
-    resources = [
-      aws_kms_key.s3_encrypted.arn,
-      aws_s3_bucket.s3_encrypted.arn,
-    "${aws_s3_bucket.s3_encrypted.arn}/*"]
-  }
-}
-
-data "aws_iam_policy_document" "read_s3" {
-  statement {
-    sid    = "AllowReadAccess"
-    effect = "Allow"
-    actions = [
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:ListBucketMultipartUploads",
-      "s3:ListMultipartUploadParts",
-      "kms:Decrypt",
-      "kms:GenerateDataKey",
-    ]
-    resources = [
-      aws_kms_key.s3_encrypted.arn,
-      aws_s3_bucket.s3_encrypted.arn,
-      "${aws_s3_bucket.s3_encrypted.arn}/*"
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "write_s3" {
-  statement {
-    sid    = "AllowWriteAccess"
-    effect = "Allow"
-    actions = [
-      "s3:PutObject",
-      "kms:GenerateDataKey",
-      "kms:Decrypt",
-    ]
-
-    resources = [
-      aws_kms_key.s3_encrypted.arn,
-      aws_s3_bucket.s3_encrypted.arn,
-      "${aws_s3_bucket.s3_encrypted.arn}/*"
-    ]
-  }
+resource "aws_s3_bucket_policy" "s3_encrypted" {
+  bucket = aws_s3_bucket.s3_encrypted.id
+  policy = data.aws_iam_policy_document.s3_encrypted.json
 }
 
 data "aws_iam_policy_document" "s3_encrypted" {
@@ -207,7 +76,7 @@ data "aws_iam_policy_document" "s3_encrypted" {
       type        = "AWS"
       identifiers = ["*"]
     }
-    actions = ["s3:PutObject", ]
+    actions = ["s3:PutObject"]
     resources = [
       "${aws_s3_bucket.s3_encrypted.arn}/*"
     ]
@@ -244,6 +113,57 @@ data "aws_iam_policy_document" "s3_encrypted" {
   }
 }
 
+############################################################################################
+## Encrypted S3 bucket logging
+############################################################################################
+
+# Create the S3 bucket to provide server access logging.
+resource "aws_s3_bucket" "s3_encrypted_log" {
+  bucket = "${var.s3_bucket_name}-logging"
+
+  # checkov:skip=CKV_AWS_144:Cross region replication not required by default
+  # checkov:skip=CKV2_AWS_61:Lifecycle policy will be added in later ticket for post-pilot cleanup
+  # checkov:skip=CKV2_AWS_62:Disable SNS requirement
+}
+resource "aws_s3_bucket_logging" "s3_encrypted_log" {
+  bucket = aws_s3_bucket.s3_encrypted.id
+  # Checkov recommends using an s3 bucket to store logging for other s3 buckets. The bucket created on #L61 is the target bucket
+  target_bucket = aws_s3_bucket.s3_encrypted_log.bucket
+  target_prefix = var.log_target_prefix
+}
+
+resource "aws_s3_bucket_versioning" "s3_encrypted_log" {
+  bucket = aws_s3_bucket.s3_encrypted_log.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "s3_encrypted_log" {
+  bucket = aws_s3_bucket.s3_encrypted_log.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.s3_encrypted.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "s3_encrypted_log" {
+  bucket = aws_s3_bucket.s3_encrypted_log.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "s3_encrypted_log" {
+  bucket = aws_s3_bucket.s3_encrypted_log.id
+  policy = data.aws_iam_policy_document.s3_encrypted_log.json
+}
+
 data "aws_iam_policy_document" "s3_encrypted_log" {
   statement {
     sid = "RequireTLS"
@@ -271,6 +191,7 @@ data "aws_iam_policy_document" "s3_encrypted_log" {
       ]
     }
   }
+
   // Allow logging.s3.amazonaws.com put objects into the s3_encrypted_log bucket.
   statement {
     sid = "S3ServerAccessLogsPolicy"
@@ -290,4 +211,107 @@ data "aws_iam_policy_document" "s3_encrypted_log" {
 
     effect = "Allow"
   }
+}
+
+############################################################################################
+## IAM policy: read
+############################################################################################
+
+resource "aws_iam_policy" "read" {
+  name        = "${var.s3_bucket_name}-read"
+  description = "Allows read access to the bucket"
+  policy      = data.aws_iam_policy_document.read.json
+}
+
+data "aws_iam_policy_document" "read" {
+  statement {
+    sid    = "AllowReadAccess"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListMultipartUploadParts",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [
+      aws_kms_key.s3_encrypted.arn,
+      aws_s3_bucket.s3_encrypted.arn,
+      "${aws_s3_bucket.s3_encrypted.arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_group_policy_attachment" "read" {
+  for_each   = toset(var.read_group_names)
+  group      = each.value
+  policy_arn = aws_iam_policy.read.arn
+}
+
+############################################################################################
+## IAM policy: write
+############################################################################################
+
+resource "aws_iam_policy" "write" {
+  name        = "${var.s3_bucket_name}-write"
+  description = "Allows write access to the bucket"
+  policy      = data.aws_iam_policy_document.write.json
+}
+
+data "aws_iam_policy_document" "write" {
+  statement {
+    sid    = "AllowWriteAccess"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+
+    resources = [
+      aws_kms_key.s3_encrypted.arn,
+      aws_s3_bucket.s3_encrypted.arn,
+      "${aws_s3_bucket.s3_encrypted.arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_group_policy_attachment" "write" {
+  for_each   = toset(var.write_group_names)
+  role       = each.value
+  policy_arn = aws_iam_policy.write.arn
+}
+
+############################################################################################
+## IAM policy: delete
+############################################################################################
+
+resource "aws_iam_policy" "delete" {
+  name        = "${var.s3_bucket_name}-delete"
+  description = "Allows delete access to the bucket"
+  policy      = data.aws_iam_policy_document.delete.json
+}
+
+data "aws_iam_policy_document" "delete" {
+  statement {
+    sid    = "AllowDelete"
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [
+      aws_kms_key.s3_encrypted.arn,
+      aws_s3_bucket.s3_encrypted.arn,
+    "${aws_s3_bucket.s3_encrypted.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "delete" {
+  for_each   = toset(var.delete_group_names)
+  role       = each.value
+  policy_arn = aws_iam_policy.delete.arn
 }

--- a/infra/modules/s3-encrypted/main.tf
+++ b/infra/modules/s3-encrypted/main.tf
@@ -279,7 +279,7 @@ data "aws_iam_policy_document" "write" {
 
 resource "aws_iam_group_policy_attachment" "write" {
   for_each   = toset(var.write_group_names)
-  role       = each.value
+  group      = each.value
   policy_arn = aws_iam_policy.write.arn
 }
 
@@ -310,8 +310,8 @@ data "aws_iam_policy_document" "delete" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "delete" {
+resource "aws_iam_group_policy_attachment" "delete" {
   for_each   = toset(var.delete_group_names)
-  role       = each.value
+  group      = each.value
   policy_arn = aws_iam_policy.delete.arn
 }

--- a/infra/modules/s3-encrypted/outputs.tf
+++ b/infra/modules/s3-encrypted/outputs.tf
@@ -1,11 +1,7 @@
-output "encrypted_bucket_id" {
-  value = aws_s3_bucket.s3_encrypted.id
+output "encrypted_bucket" {
+  value = aws_s3_bucket.s3_encrypted
 }
 
-output "encrypted_bucket_arn" {
-  value = aws_s3_bucket.s3_encrypted.arn
-}
-
-output "bucket_kms_arn" {
-  value = aws_kms_key.s3_encrypted.arn
+output "encrypted_bucket_kms" {
+  value = aws_kms_key.s3_encrypted
 }

--- a/infra/modules/s3-encrypted/variables.tf
+++ b/infra/modules/s3-encrypted/variables.tf
@@ -1,28 +1,28 @@
-variable "write_role_names" {
-  type        = list(string)
-  description = "role names that have access to write s3 permissions"
-  default     = []
-}
-
-variable "delete_role_names" {
-  type        = list(string)
-  description = "role names that have access to delete s3 permissions"
-  default     = []
-}
-
-variable "read_role_names" {
-  type        = list(string)
-  description = "role names that have access to read s3 permissions"
-  default     = []
-}
-
-variable "admin_role_names" {
-  type        = list(string)
-  description = "role names that have access to admin s3 permissions, such as creating buckets"
-  default     = []
-}
-
 variable "s3_bucket_name" {
   type        = string
-  description = "The s3 bucket used for document uploads"
+  description = "The name of the S3 bucket"
 }
+
+variable "log_target_prefix" {
+  type        = string
+  description = "The prefix for all log object keys"
+}
+
+variable "read_group_names" {
+  type        = list(string)
+  description = "A list of names for IAM groups that should have access to read access to the encrypted S3 bucket"
+  default     = []
+}
+
+variable "write_group_names" {
+  type        = list(string)
+  description = "A list of names for IAM groups that should have access to write access to the encrypted S3 bucket"
+  default     = []
+}
+
+variable "delete_group_names" {
+  type        = list(string)
+  description = "A list of names for IAM groups that should have access to delete access to the encrypted S3 bucket"
+  default     = []
+}
+

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -294,8 +294,9 @@ resource "aws_cloudwatch_log_group" "service_logs" {
 ####################
 
 module "alb_logging" {
-  source         = "../s3-encrypted"
-  s3_bucket_name = var.service_name
+  source            = "../s3-encrypted"
+  s3_bucket_name    = var.service_name
+  log_target_prefix = var.service_name
 }
 
 ####################

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -372,7 +372,7 @@ data "aws_iam_policy_document" "task_executor" {
       actions = [
         "ssm:GetParameters",
       ]
-      resources = ["arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${statement.value}"]
+      resources = [statement.value]
     }
   }
 }

--- a/infra/modules/waf/main.tf
+++ b/infra/modules/waf/main.tf
@@ -274,18 +274,19 @@ resource "aws_cloudwatch_log_group" "waf" {
   name              = var.waf_logging_name # make this a variable
   retention_in_days = 30
 
-  # Checkov throws alerts in the event of default encryption for Cloudwatch,which is server-side encrytion for data at rest. 
-  # checkov:skip=CKV_AWS_158:Disabling this becuase if the key is deleted or otherwise unassociated, the cloudwatch logs will be inaccessible. 
+  # Checkov throws alerts in the event of default encryption for Cloudwatch,which is server-side encrytion for data at rest.
+  # checkov:skip=CKV_AWS_158:Disabling this becuase if the key is deleted or otherwise unassociated, the cloudwatch logs will be inaccessible.
 }
 
 # s3 logging bucket; this is a refactor to DRY up the code
 module "s3_encrypted_bucket" {
-  source         = "../s3-encrypted"
-  s3_bucket_name = "wic-prp-waf"
+  source            = "../s3-encrypted"
+  s3_bucket_name    = "wic-prp-waf"
+  log_target_prefix = "waf"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "waf_logging" {
-  bucket                = module.s3_encrypted_bucket.encrypted_bucket_id
+  bucket                = module.s3_encrypted_bucket.encrypted_bucket.id
   expected_bucket_owner = data.aws_caller_identity.current.account_id
 
   rule {


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-344

## Changes
> What was added, updated, or removed in this PR.

- Adds a script to be able to manually refresh S3 urls on-demand
- Creates a machine IAM user for longer S3 presigned url expiration time
- Supplies the machine IAM user's access credentials to the participant task definition
- Changes the s3-encrypted terraform module to grant permissions to an IAM group rather than an IAM role
- Drops the no-longer-used admin permissions in the s3-encrypted terraform module
- Refactors away SSM Parameter Store names and instead passes arns
- Starts the process of adding more organization and inline code documentation to the infra codebase

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

According to the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html), maximum S3 presigned url expiration time for STS is tied to the maximum session duration of the assumed role (which can be 12 hours at most); whereas maximum S3 presigned url expiration time for an IAM user is 7 days.

This PR creates a machine IAM user to take advantage of the longer expiration time. It therefore also lowers the refresh frequency introduced in the previous hotfix #105. This PR changes the Eventbridge check to run once a day and update any urls that haven't been updated in the last 4 days. **Important: The first time this is run, we need to refresh all the urls, so that the old expiration times are caught.**

This PR also starts to add more inline code documentation to the infra codebase.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

- I've deployed this to the `dev` environment
- On 2023-05-16 @ ~3:50pm PT, I also ran a one time `aws ecs run-task` to the `dev` environment to refresh all the urls (see [log](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/service$252Fwic-prp-participant-dev/log-events/wic-prp-participant-dev$252Fwic-prp-participant-dev$252F7cb1b3499fbf40c2b62a7e3fa3b9369e) where it updated 82 documents)
- We should see over the next several days that the eventbridge tasks should not find any urls to update AND that the urls should still work in the staff portal