### PR TITLE
Prp 329 dob

### DIFF
--- a/participant/app/components/DateInput.tsx
+++ b/participant/app/components/DateInput.tsx
@@ -1,7 +1,13 @@
-import { ReactElement, useState } from "react";
-import { Fieldset, DateInputGroup, FormGroup, Label, ErrorMessage } from "@trussworks/react-uswds";
+import type { ReactElement } from "react";
+import {
+  Fieldset,
+  DateInputGroup,
+  FormGroup,
+  Label,
+  ErrorMessage,
+} from "@trussworks/react-uswds";
 import Required from "app/components/Required";
-import { TextInput } from "@trussworks/react-uswds"
+import { TextInput } from "@trussworks/react-uswds";
 import { useField } from "remix-validated-form";
 import type { i18nKey, legendStyleType } from "~/types";
 import { Trans, useTranslation } from "react-i18next";
@@ -46,9 +52,9 @@ export const DateInput = (props: DateInputProps): ReactElement => {
     </div>
   );
   const onBlurFunc = () => {
-    clearError()
-    validate()
-  }
+    clearError();
+    validate();
+  };
   const hintKey = DMYorder ? `${dateKey}.hintDMY` : `${dateKey}.hintMDY`;
   const hintElement =
     hint && t(hintKey) ? (
@@ -81,7 +87,9 @@ export const DateInput = (props: DateInputProps): ReactElement => {
   });
   return (
     <Fieldset legend={legendElement} legendStyle={legendStyle}>
-      {error && <ErrorMessage id={`${name}-error-message`}>{error}</ErrorMessage>}
+      {error && (
+        <ErrorMessage id={`${name}-error-message`}>{error}</ErrorMessage>
+      )}
       {hintElement}
       <DateInputGroup>{orderedDateFields}</DateInputGroup>
     </Fieldset>

--- a/participant/app/components/DateInput.tsx
+++ b/participant/app/components/DateInput.tsx
@@ -1,7 +1,8 @@
-import type { ReactElement } from "react";
-import { Fieldset, DateInputGroup, FormGroup } from "@trussworks/react-uswds";
+import { ReactElement, useState } from "react";
+import { Fieldset, DateInputGroup, FormGroup, Label, ErrorMessage } from "@trussworks/react-uswds";
 import Required from "app/components/Required";
-import { TextField } from "app/components/TextField";
+import { TextInput } from "@trussworks/react-uswds"
+import { useField } from "remix-validated-form";
 import type { i18nKey, legendStyleType } from "~/types";
 import { Trans, useTranslation } from "react-i18next";
 
@@ -37,12 +38,17 @@ export const DateInput = (props: DateInputProps): ReactElement => {
     values,
   } = props;
   const { t } = useTranslation();
+  const { error, clearError, validate } = useField(name);
   const legendElement = (
     <div>
       <Trans i18nKey={legendKey} />
       {required ? <Required /> : ""}
     </div>
   );
+  const onBlurFunc = () => {
+    clearError()
+    validate()
+  }
   const hintKey = DMYorder ? `${dateKey}.hintDMY` : `${dateKey}.hintMDY`;
   const hintElement =
     hint && t(hintKey) ? (
@@ -50,7 +56,6 @@ export const DateInput = (props: DateInputProps): ReactElement => {
         <Trans i18nKey={hintKey} />
       </div>
     ) : undefined;
-
   const orderedFields: DateFieldTypes[] = DMYorder
     ? ["day", "month", "year"]
     : ["month", "day", "year"];
@@ -61,14 +66,14 @@ export const DateInput = (props: DateInputProps): ReactElement => {
         className={`usa-form-group--${field}`}
         key={`${keyBase}-${field}`}
       >
-        <TextField
+        <Label htmlFor={`${name}.${field}`}>{t(`${dateKey}.${field}`)}</Label>
+        <TextInput
           id={`${name}.${field}`}
-          labelKey={`${dateKey}.${field}`}
+          name={`${name}.${field}`}
           size={maxLength}
-          inputType="text"
-          type="input"
+          type="text"
           required={required}
-          requiredStar={false}
+          onBlur={onBlurFunc}
           defaultValue={values && values[field]?.toString()}
         />
       </FormGroup>
@@ -76,6 +81,7 @@ export const DateInput = (props: DateInputProps): ReactElement => {
   });
   return (
     <Fieldset legend={legendElement} legendStyle={legendStyle}>
+      {error && <ErrorMessage id={`${name}-error-message`}>{error}</ErrorMessage>}
       {hintElement}
       <DateInputGroup>{orderedDateFields}</DateInputGroup>
     </Fieldset>

--- a/participant/app/utils/validation.ts
+++ b/participant/app/utils/validation.ts
@@ -91,39 +91,46 @@ export const participantSchema = zfd.formData({
       ),
       preferredName: zfd.text(z.string().optional()),
 
-      dob: z.object({
-        day: zfd.numeric(
-          z
-            .number()
-            .min(1, {
-              message:
-                "Date of birth must include a valid month, day, and year.",
-            })
-            .max(31, {
-              message:
-                "Date of birth must include a valid month, day, and year.",
-            })
-        ),
-        month: zfd.numeric(
-          z
-            .number()
-            .min(1, {
-              message:
-                "Date of birth must include a valid month, day, and year.",
-            })
-            .max(12, {
-              message:
-                "Date of birth must include a valid month, day, and year.",
-            })
-        ),
-        year: zfd.numeric(
-          z
-            .number()
-            .min(1912, { message: "Enter a valid date of birth." })
-            .max(2023, {
-              message: "Date of birth must be today or in the past.",
-            })
-        ),
+      dob: z.object({ day: zfd.numeric(), month: zfd.numeric(), year: zfd.numeric() }).superRefine((val, ctx) => {
+        console.log(`DATE VALIDATOR ${JSON.stringify(val)}`)
+        if (!val.year || !val.month || !val.day) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Date of birth must include a valid month, day, and year.",
+          });
+          return z.NEVER;
+        }
+        const date = new Date(val.year, val.month - 1, val.day)
+        if (date.valueOf() == undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Enter a valid date of birth",
+          });
+          return z.NEVER;
+        }
+        if (date.getMonth() != val.month - 1 || date.getDate() != val.day) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Date of birth must include a valid month, day, and year.",
+          });
+          return z.NEVER;
+        }
+        if (val.year < 1912) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Enter a valid date of birth.",
+          })
+          return z.NEVER;
+
+        }
+        if (date > new Date()) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Date of birth must be today or in the past.",
+          })
+          return z.NEVER;
+        }
+
       }),
       adjunctive: zfd.text(
         z.enum(["yes", "no"], {

--- a/participant/app/utils/validation.ts
+++ b/participant/app/utils/validation.ts
@@ -107,6 +107,7 @@ export const participantSchema = zfd.formData({
             return z.NEVER;
           }
           const date = new Date(val.year, val.month - 1, val.day);
+          const now = new Date();
           if (date.valueOf() == undefined) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
@@ -122,14 +123,14 @@ export const participantSchema = zfd.formData({
             });
             return z.NEVER;
           }
-          if (val.year < 1912) {
+          if (date.getFullYear() < now.getFullYear() - 110) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               message: "Enter a valid date of birth.",
             });
             return z.NEVER;
           }
-          if (date > new Date()) {
+          if (date > now) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               message: "Date of birth must be today or in the past.",

--- a/participant/app/utils/validation.ts
+++ b/participant/app/utils/validation.ts
@@ -91,47 +91,52 @@ export const participantSchema = zfd.formData({
       ),
       preferredName: zfd.text(z.string().optional()),
 
-      dob: z.object({ day: zfd.numeric(), month: zfd.numeric(), year: zfd.numeric() }).superRefine((val, ctx) => {
-        console.log(`DATE VALIDATOR ${JSON.stringify(val)}`)
-        if (!val.year || !val.month || !val.day) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: "Date of birth must include a valid month, day, and year.",
-          });
-          return z.NEVER;
-        }
-        const date = new Date(val.year, val.month - 1, val.day)
-        if (date.valueOf() == undefined) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: "Enter a valid date of birth",
-          });
-          return z.NEVER;
-        }
-        if (date.getMonth() != val.month - 1 || date.getDate() != val.day) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: "Date of birth must include a valid month, day, and year.",
-          });
-          return z.NEVER;
-        }
-        if (val.year < 1912) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: "Enter a valid date of birth.",
-          })
-          return z.NEVER;
-
-        }
-        if (date > new Date()) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: "Date of birth must be today or in the past.",
-          })
-          return z.NEVER;
-        }
-
-      }),
+      dob: z
+        .object({
+          day: zfd.numeric(),
+          month: zfd.numeric(),
+          year: zfd.numeric(),
+        })
+        .superRefine((val, ctx) => {
+          if (!val.year || !val.month || !val.day) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message:
+                "Date of birth must include a valid month, day, and year.",
+            });
+            return z.NEVER;
+          }
+          const date = new Date(val.year, val.month - 1, val.day);
+          if (date.valueOf() == undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "Enter a valid date of birth",
+            });
+            return z.NEVER;
+          }
+          if (date.getMonth() != val.month - 1 || date.getDate() != val.day) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message:
+                "Date of birth must include a valid month, day, and year.",
+            });
+            return z.NEVER;
+          }
+          if (val.year < 1912) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "Enter a valid date of birth.",
+            });
+            return z.NEVER;
+          }
+          if (date > new Date()) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "Date of birth must be today or in the past.",
+            });
+            return z.NEVER;
+          }
+        }),
       adjunctive: zfd.text(
         z.enum(["yes", "no"], {
           required_error:

--- a/participant/tests/utils/isValidDetails.test.ts
+++ b/participant/tests/utils/isValidDetails.test.ts
@@ -103,7 +103,7 @@ it("should have an error if dob.month is incorrect", async () => {
   );
   expect(validationResult.data).toBeUndefined();
   expect(validationResult.error?.fieldErrors).toStrictEqual({
-    "participant[0].dob.month":
+    "participant[0].dob":
       "Date of birth must include a valid month, day, and year.",
   });
 });
@@ -136,7 +136,7 @@ it("should have an error if dob.day is incorrect", async () => {
   );
   expect(validationResult.data).toBeUndefined();
   expect(validationResult.error?.fieldErrors).toStrictEqual({
-    "participant[0].dob.day":
+    "participant[0].dob":
       "Date of birth must include a valid month, day, and year.",
   });
 });
@@ -169,7 +169,7 @@ it("should have an error if dob.year is too early", async () => {
   );
   expect(validationResult.data).toBeUndefined();
   expect(validationResult.error?.fieldErrors).toStrictEqual({
-    "participant[0].dob.year": "Enter a valid date of birth.",
+    "participant[0].dob": "Enter a valid date of birth.",
   });
 });
 
@@ -186,7 +186,7 @@ it("should have an error if dob.year is back to the future", async () => {
   );
   expect(validationResult.data).toBeUndefined();
   expect(validationResult.error?.fieldErrors).toStrictEqual({
-    "participant[0].dob.year": "Date of birth must be today or in the past.",
+    "participant[0].dob": "Date of birth must be today or in the past.",
   });
 });
 


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-329

## Changes
* DateInput is now one field for validation
* Rewrote validation
* DateInput now uses Truss USWDS TextInput fields instead of TextField components



## Testing
Enter bad dates, see one error message instead of the tectonic field shifts there were previously

![datepicker](https://github.com/navapbc/wic-participant-recertification-portal/assets/723391/41d7efca-fdd3-4e11-9dae-125176767dff)

