### PR TITLE
[PRP-352] Separate s3 bucket for application vs logging

### DIFF
--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -29,6 +29,7 @@ locals {
   document_upload_s3_name                 = "${local.project_name}-doc-upload-${var.environment_name}"
   refresh_s3_presigned_urls_schedule_name = "${local.project_name}-s3-refresh-schedule-${var.environment_name}"
   side_load_s3_name                       = "${local.project_name}-side-load-${var.environment_name}"
+  s3_logging_bucket_name                  = "${local.project_name}-s3-logging-${var.environment_name}"
   contact_email                           = "wic-projects-team@navapbc.com"
   staff_idp_client_domain                 = "${var.environment_name}-idp.wic-services.org"
   waf_name                                = "${local.project_name}-${local.project_name}-waf" # @TODO this should be cleaned up with the root module centralization
@@ -57,6 +58,17 @@ data "aws_subnets" "default" {
 }
 
 ############################################################################################
+## S3 logging bucket
+## - Creates an S3 bucket for logging purposes
+## - Resources that log to this bucket include: doc upload and side load s3 buckets and ALB
+############################################################################################
+
+module "s3_logging_bucket" {
+  source              = "../../modules/s3-logging"
+  logging_bucket_name = local.s3_logging_bucket_name
+}
+
+############################################################################################
 ## Document upload
 ## - Creates an IAM user to pass to the AWS SDK in the participant app for S3 operations
 ## - Creates an S3 bucket
@@ -71,12 +83,12 @@ module "s3_machine_user" {
 }
 
 module "doc_upload" {
-  source             = "../../modules/s3-encrypted"
-  s3_bucket_name     = local.document_upload_s3_name
-  log_target_prefix  = var.environment_name
-  read_group_names   = [module.s3_machine_user.machine_user_group_name]
-  write_group_names  = [module.s3_machine_user.machine_user_group_name]
-  delete_group_names = [module.s3_machine_user.machine_user_group_name]
+  source               = "../../modules/s3-encrypted"
+  s3_bucket_name       = local.document_upload_s3_name
+  s3_logging_bucket_id = module.s3_logging_bucket.bucket_id
+  read_group_names     = [module.s3_machine_user.machine_user_group_name]
+  write_group_names    = [module.s3_machine_user.machine_user_group_name]
+  delete_group_names   = [module.s3_machine_user.machine_user_group_name]
 }
 
 resource "aws_s3_bucket_cors_configuration" "doc_upload_cors" {
@@ -136,6 +148,7 @@ module "participant" {
   image_repository_url               = data.aws_ecr_repository.participant_image_repository.repository_url
   image_repository_arn               = data.aws_ecr_repository.participant_image_repository.arn
   waf_name                           = local.waf_name
+  s3_logging_bucket_name             = module.s3_logging_bucket.bucket_name
   image_tag                          = var.participant_image_tag
   vpc_id                             = data.aws_vpc.default.id
   subnet_ids                         = data.aws_subnets.default.ids
@@ -256,10 +269,10 @@ module "refresh_s3_presigned_urls" {
 }
 
 module "side_load" {
-  source            = "../../modules/s3-encrypted"
-  s3_bucket_name    = local.side_load_s3_name
-  log_target_prefix = var.environment_name
-  read_group_names  = [module.s3_machine_user.machine_user_group_name]
+  source               = "../../modules/s3-encrypted"
+  s3_bucket_name       = local.side_load_s3_name
+  s3_logging_bucket_id = module.s3_logging_bucket.bucket_id
+  read_group_names     = [module.s3_machine_user.machine_user_group_name]
 }
 
 ############################################################################################
@@ -316,19 +329,20 @@ module "staff_dns" {
 }
 
 module "staff" {
-  source               = "../../modules/service"
-  service_name         = local.staff_service_name
-  image_repository_url = data.aws_ecr_repository.staff_image_repository.repository_url
-  waf_name             = local.waf_name
-  image_repository_arn = data.aws_ecr_repository.staff_image_repository.arn
-  image_tag            = var.staff_image_tag
-  vpc_id               = data.aws_vpc.default.id
-  subnet_ids           = data.aws_subnets.default.ids
-  ssl_cert_arn         = data.aws_acm_certificate.ssl_cert.arn
-  service_cluster_arn  = module.service_cluster.service_cluster_arn
-  container_port       = 3000
-  enable_exec          = var.staff_enable_exec
-  enable_healthcheck   = false
+  source                 = "../../modules/service"
+  service_name           = local.staff_service_name
+  image_repository_url   = data.aws_ecr_repository.staff_image_repository.repository_url
+  waf_name               = local.waf_name
+  s3_logging_bucket_name = module.s3_logging_bucket.bucket_name
+  image_repository_arn   = data.aws_ecr_repository.staff_image_repository.arn
+  image_tag              = var.staff_image_tag
+  vpc_id                 = data.aws_vpc.default.id
+  subnet_ids             = data.aws_subnets.default.ids
+  ssl_cert_arn           = data.aws_acm_certificate.ssl_cert.arn
+  service_cluster_arn    = module.service_cluster.service_cluster_arn
+  container_port         = 3000
+  enable_exec            = var.staff_enable_exec
+  enable_healthcheck     = false
   container_secrets = [
     {
       name      = "LOWDEFY_SECRET_PG_CONNECTION_STRING",
@@ -410,6 +424,7 @@ module "analytics" {
   service_name             = local.analytics_service_name
   image_repository_url     = data.aws_ecr_repository.analytics_image_repository.repository_url
   waf_name                 = local.waf_name
+  s3_logging_bucket_name   = module.s3_logging_bucket.bucket_name
   image_repository_arn     = data.aws_ecr_repository.analytics_image_repository.arn
   image_tag                = var.analytics_image_tag
   vpc_id                   = data.aws_vpc.default.id

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -148,7 +148,7 @@ module "participant" {
   image_repository_url               = data.aws_ecr_repository.participant_image_repository.repository_url
   image_repository_arn               = data.aws_ecr_repository.participant_image_repository.arn
   waf_name                           = local.waf_name
-  s3_logging_bucket_name             = module.s3_logging_bucket.bucket_name
+  s3_logging_bucket_id             = module.s3_logging_bucket.bucket_id
   image_tag                          = var.participant_image_tag
   vpc_id                             = data.aws_vpc.default.id
   subnet_ids                         = data.aws_subnets.default.ids
@@ -333,7 +333,7 @@ module "staff" {
   service_name           = local.staff_service_name
   image_repository_url   = data.aws_ecr_repository.staff_image_repository.repository_url
   waf_name               = local.waf_name
-  s3_logging_bucket_name = module.s3_logging_bucket.bucket_name
+  s3_logging_bucket_id = module.s3_logging_bucket.bucket_id
   image_repository_arn   = data.aws_ecr_repository.staff_image_repository.arn
   image_tag              = var.staff_image_tag
   vpc_id                 = data.aws_vpc.default.id
@@ -424,7 +424,7 @@ module "analytics" {
   service_name             = local.analytics_service_name
   image_repository_url     = data.aws_ecr_repository.analytics_image_repository.repository_url
   waf_name                 = local.waf_name
-  s3_logging_bucket_name   = module.s3_logging_bucket.bucket_name
+  s3_logging_bucket_id   = module.s3_logging_bucket.bucket_id
   image_repository_arn     = data.aws_ecr_repository.analytics_image_repository.arn
   image_tag                = var.analytics_image_tag
   vpc_id                   = data.aws_vpc.default.id

--- a/infra/app/env-template/main.tf
+++ b/infra/app/env-template/main.tf
@@ -148,7 +148,7 @@ module "participant" {
   image_repository_url               = data.aws_ecr_repository.participant_image_repository.repository_url
   image_repository_arn               = data.aws_ecr_repository.participant_image_repository.arn
   waf_name                           = local.waf_name
-  s3_logging_bucket_id             = module.s3_logging_bucket.bucket_id
+  s3_logging_bucket_id               = module.s3_logging_bucket.bucket_id
   image_tag                          = var.participant_image_tag
   vpc_id                             = data.aws_vpc.default.id
   subnet_ids                         = data.aws_subnets.default.ids
@@ -329,20 +329,20 @@ module "staff_dns" {
 }
 
 module "staff" {
-  source                 = "../../modules/service"
-  service_name           = local.staff_service_name
-  image_repository_url   = data.aws_ecr_repository.staff_image_repository.repository_url
-  waf_name               = local.waf_name
+  source               = "../../modules/service"
+  service_name         = local.staff_service_name
+  image_repository_url = data.aws_ecr_repository.staff_image_repository.repository_url
+  waf_name             = local.waf_name
   s3_logging_bucket_id = module.s3_logging_bucket.bucket_id
-  image_repository_arn   = data.aws_ecr_repository.staff_image_repository.arn
-  image_tag              = var.staff_image_tag
-  vpc_id                 = data.aws_vpc.default.id
-  subnet_ids             = data.aws_subnets.default.ids
-  ssl_cert_arn           = data.aws_acm_certificate.ssl_cert.arn
-  service_cluster_arn    = module.service_cluster.service_cluster_arn
-  container_port         = 3000
-  enable_exec            = var.staff_enable_exec
-  enable_healthcheck     = false
+  image_repository_arn = data.aws_ecr_repository.staff_image_repository.arn
+  image_tag            = var.staff_image_tag
+  vpc_id               = data.aws_vpc.default.id
+  subnet_ids           = data.aws_subnets.default.ids
+  ssl_cert_arn         = data.aws_acm_certificate.ssl_cert.arn
+  service_cluster_arn  = module.service_cluster.service_cluster_arn
+  container_port       = 3000
+  enable_exec          = var.staff_enable_exec
+  enable_healthcheck   = false
   container_secrets = [
     {
       name      = "LOWDEFY_SECRET_PG_CONNECTION_STRING",
@@ -424,7 +424,7 @@ module "analytics" {
   service_name             = local.analytics_service_name
   image_repository_url     = data.aws_ecr_repository.analytics_image_repository.repository_url
   waf_name                 = local.waf_name
-  s3_logging_bucket_id   = module.s3_logging_bucket.bucket_id
+  s3_logging_bucket_id     = module.s3_logging_bucket.bucket_id
   image_repository_arn     = data.aws_ecr_repository.analytics_image_repository.arn
   image_tag                = var.analytics_image_tag
   vpc_id                   = data.aws_vpc.default.id

--- a/infra/modules/s3-encrypted/main.tf
+++ b/infra/modules/s3-encrypted/main.tf
@@ -41,6 +41,12 @@ resource "aws_s3_bucket" "s3_encrypted" {
   # checkov:skip=CKV2_AWS_62:Disable SNS requirement
 }
 
+resource "aws_s3_bucket_logging" "s3_encrypted_log" {
+  bucket        = aws_s3_bucket.s3_encrypted.id
+  target_bucket = var.s3_logging_bucket_id
+  target_prefix = "s3/${var.s3_bucket_name}/"
+}
+
 resource "aws_s3_bucket_versioning" "s3_encrypted" {
   bucket = aws_s3_bucket.s3_encrypted.id
 
@@ -117,17 +123,6 @@ data "aws_iam_policy_document" "s3_encrypted" {
       ]
     }
   }
-}
-
-############################################################################################
-## Bucket logging
-## - Checkov recommends using an s3 bucket to store logging for other s3 buckets
-############################################################################################
-
-resource "aws_s3_bucket_logging" "s3_encrypted_log" {
-  bucket        = aws_s3_bucket.s3_encrypted.id
-  target_bucket = var.s3_logging_bucket_id
-  target_prefix = "s3/${var.s3_bucket_name}/"
 }
 
 ############################################################################################

--- a/infra/modules/s3-encrypted/main.tf
+++ b/infra/modules/s3-encrypted/main.tf
@@ -38,7 +38,6 @@ resource "aws_s3_bucket" "s3_encrypted" {
 
   # checkov:skip=CKV_AWS_144:Cross region replication not required by default
   # checkov:skip=CKV2_AWS_61:Lifecycle policy will be added in later ticket for post-pilot cleanup
-  # checkov:skip=CKV_AWS_18:Logging is enabled; but checkov can't find it
   # checkov:skip=CKV2_AWS_62:Disable SNS requirement
 }
 

--- a/infra/modules/s3-encrypted/main.tf
+++ b/infra/modules/s3-encrypted/main.tf
@@ -17,9 +17,15 @@ data "aws_region" "current" {}
 
 resource "aws_kms_key" "s3_encrypted" {
   description = "KMS key for encrypted S3 bucket"
-  # The waiting period, specified in number of days. After receiving a deletion request, AWS KMS will delete the KMS key after the waiting period ends. During the waiting period, the KMS key status and key state is Pending deletion. See https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html#deleting-keys-how-it-works
+
+  # The waiting period, specified in number of days. After receiving a deletion request,
+  # AWS KMS will delete the KMS key after the waiting period ends. During the waiting period,
+  # the KMS key status and key state is Pending deletion.
+  # See https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html#deleting-keys-how-it-works
   deletion_window_in_days = "10"
-  # Generates new cryptographic material every 365 days, this is used to encrypt your data. The KMS key retains the old material for decryption purposes.
+
+  # Generates new cryptographic material every 365 days, this is used to encrypt your data.
+  # The KMS key retains the old material for decryption purposes.
   enable_key_rotation = "true"
 }
 
@@ -114,103 +120,14 @@ data "aws_iam_policy_document" "s3_encrypted" {
 }
 
 ############################################################################################
-## Encrypted S3 bucket logging
+## Bucket logging
+## - Checkov recommends using an s3 bucket to store logging for other s3 buckets
 ############################################################################################
 
-# Create the S3 bucket to provide server access logging.
-resource "aws_s3_bucket" "s3_encrypted_log" {
-  bucket = "${var.s3_bucket_name}-logging"
-
-  # checkov:skip=CKV_AWS_144:Cross region replication not required by default
-  # checkov:skip=CKV2_AWS_61:Lifecycle policy will be added in later ticket for post-pilot cleanup
-  # checkov:skip=CKV2_AWS_62:Disable SNS requirement
-}
 resource "aws_s3_bucket_logging" "s3_encrypted_log" {
-  bucket = aws_s3_bucket.s3_encrypted.id
-  # Checkov recommends using an s3 bucket to store logging for other s3 buckets. The bucket created on #L61 is the target bucket
-  target_bucket = aws_s3_bucket.s3_encrypted_log.bucket
-  target_prefix = var.log_target_prefix
-}
-
-resource "aws_s3_bucket_versioning" "s3_encrypted_log" {
-  bucket = aws_s3_bucket.s3_encrypted_log.id
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "s3_encrypted_log" {
-  bucket = aws_s3_bucket.s3_encrypted_log.bucket
-
-  rule {
-    apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.s3_encrypted.arn
-      sse_algorithm     = "aws:kms"
-    }
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "s3_encrypted_log" {
-  bucket = aws_s3_bucket.s3_encrypted_log.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource "aws_s3_bucket_policy" "s3_encrypted_log" {
-  bucket = aws_s3_bucket.s3_encrypted_log.id
-  policy = data.aws_iam_policy_document.s3_encrypted_log.json
-}
-
-data "aws_iam_policy_document" "s3_encrypted_log" {
-  statement {
-    sid = "RequireTLS"
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-    actions = [
-      "s3:*",
-    ]
-
-    resources = [
-      aws_s3_bucket.s3_encrypted_log.arn,
-      "${aws_s3_bucket.s3_encrypted_log.arn}/*"
-    ]
-
-    effect = "Deny"
-
-    condition {
-      test     = "Bool"
-      variable = "aws:SecureTransport"
-
-      values = [
-        false
-      ]
-    }
-  }
-
-  # Allow logging.s3.amazonaws.com put objects into the s3_encrypted_log bucket.
-  statement {
-    sid = "S3ServerAccessLogsPolicy"
-    principals {
-      type = "Service"
-      identifiers = [
-        "logging.s3.amazonaws.com"
-      ]
-    }
-    actions = [
-      "s3:PutObject",
-    ]
-
-    resources = [
-      "${aws_s3_bucket.s3_encrypted_log.arn}/*"
-    ]
-
-    effect = "Allow"
-  }
+  bucket        = aws_s3_bucket.s3_encrypted.id
+  target_bucket = var.s3_logging_bucket_id
+  target_prefix = "s3/${var.s3_bucket_name}/"
 }
 
 ############################################################################################

--- a/infra/modules/s3-encrypted/main.tf
+++ b/infra/modules/s3-encrypted/main.tf
@@ -38,8 +38,8 @@ resource "aws_s3_bucket" "s3_encrypted" {
 
   # checkov:skip=CKV_AWS_144:Cross region replication not required by default
   # checkov:skip=CKV2_AWS_61:Lifecycle policy will be added in later ticket for post-pilot cleanup
+  # checkov:skip=CKV_AWS_18:Logging is enabled; but checkov can't find it
   # checkov:skip=CKV2_AWS_62:Disable SNS requirement
-  # checkov:skip=CKV_AWS_18:Checkov is unable to detect that access logging is enabled in the next resource
 }
 
 resource "aws_s3_bucket_logging" "s3_encrypted" {

--- a/infra/modules/s3-encrypted/main.tf
+++ b/infra/modules/s3-encrypted/main.tf
@@ -39,9 +39,10 @@ resource "aws_s3_bucket" "s3_encrypted" {
   # checkov:skip=CKV_AWS_144:Cross region replication not required by default
   # checkov:skip=CKV2_AWS_61:Lifecycle policy will be added in later ticket for post-pilot cleanup
   # checkov:skip=CKV2_AWS_62:Disable SNS requirement
+  # checkov:skip=CKV_AWS_18:Checkov is unable to detect that access logging is enabled in the next resource
 }
 
-resource "aws_s3_bucket_logging" "s3_encrypted_log" {
+resource "aws_s3_bucket_logging" "s3_encrypted" {
   bucket        = aws_s3_bucket.s3_encrypted.id
   target_bucket = var.s3_logging_bucket_id
   target_prefix = "s3/${var.s3_bucket_name}/"

--- a/infra/modules/s3-encrypted/variables.tf
+++ b/infra/modules/s3-encrypted/variables.tf
@@ -3,9 +3,9 @@ variable "s3_bucket_name" {
   description = "The name of the S3 bucket"
 }
 
-variable "log_target_prefix" {
+variable "s3_logging_bucket_id" {
   type        = string
-  description = "The prefix for all log object keys"
+  description = "The ID for the s3 bucket used for logging for this bucket"
 }
 
 variable "read_group_names" {

--- a/infra/modules/s3-logging/main.tf
+++ b/infra/modules/s3-logging/main.tf
@@ -1,0 +1,122 @@
+############################################################################################
+## A module for creating an encrypted S3 bucket for logging purposes
+## - With associated S3 bucket policies and access management
+## - Also creates an encrypted S3 bucket for logging operations
+## - Creates IAM policies:
+##   - IAM policies in this module are broken out into read, write, and delete
+##     so that these permissions can be modularly assigned to different user groups by the
+##     module calling this one.
+############################################################################################
+
+############################################################################################
+## KMS key
+############################################################################################
+
+resource "aws_kms_key" "s3_encrypted_log" {
+  description = "KMS key for encrypted S3 bucket"
+
+  # The waiting period, specified in number of days. After receiving a deletion request,
+  # AWS KMS will delete the KMS key after the waiting period ends. During the waiting period,
+  # the KMS key status and key state is Pending deletion.
+  # See https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html#deleting-keys-how-it-works
+  deletion_window_in_days = "10"
+
+  # Generates new cryptographic material every 365 days, this is used to encrypt your data.
+  # The KMS key retains the old material for decryption purposes.
+  enable_key_rotation = "true"
+}
+
+############################################################################################
+## Encrypted S3 bucket logging
+############################################################################################
+
+# Create the S3 bucket to provide server access logging.
+resource "aws_s3_bucket" "s3_encrypted_log" {
+  bucket = var.logging_bucket_name
+
+  # checkov:skip=CKV_AWS_144:Cross region replication not required by default
+  # checkov:skip=CKV2_AWS_61:Lifecycle policy will be added in later ticket for post-pilot cleanup
+  # checkov:skip=CKV2_AWS_62:Disable SNS requirement
+}
+
+resource "aws_s3_bucket_versioning" "s3_encrypted_log" {
+  bucket = aws_s3_bucket.s3_encrypted_log.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "s3_encrypted_log" {
+  bucket = aws_s3_bucket.s3_encrypted_log.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.s3_encrypted_log.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "s3_encrypted_log" {
+  bucket = aws_s3_bucket.s3_encrypted_log.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "s3_encrypted_log" {
+  bucket = aws_s3_bucket.s3_encrypted_log.id
+  policy = data.aws_iam_policy_document.s3_encrypted_log.json
+}
+
+data "aws_iam_policy_document" "s3_encrypted_log" {
+  statement {
+    sid = "RequireTLS"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      aws_s3_bucket.s3_encrypted_log.arn,
+      "${aws_s3_bucket.s3_encrypted_log.arn}/*"
+    ]
+
+    effect = "Deny"
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+
+      values = [
+        false
+      ]
+    }
+  }
+
+  # Allow logging.s3.amazonaws.com put objects into the s3_encrypted_log bucket.
+  statement {
+    sid = "S3ServerAccessLogsPolicy"
+    principals {
+      type = "Service"
+      identifiers = [
+        "logging.s3.amazonaws.com"
+      ]
+    }
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.s3_encrypted_log.arn}/*"
+    ]
+
+    effect = "Allow"
+  }
+}

--- a/infra/modules/s3-logging/main.tf
+++ b/infra/modules/s3-logging/main.tf
@@ -15,6 +15,7 @@ resource "aws_s3_bucket" "s3_encrypted_log" {
   # checkov:skip=CKV_AWS_144:Cross region replication not required by default
   # checkov:skip=CKV2_AWS_61:Lifecycle policy will be added in later ticket for post-pilot cleanup
   # checkov:skip=CKV2_AWS_62:Disable SNS requirement
+  # checkov:skip=CKV_AWS_145:Access logging for s3 and elb does not support KMS SSE encryption
 }
 
 resource "aws_s3_bucket_versioning" "s3_encrypted_log" {

--- a/infra/modules/s3-logging/main.tf
+++ b/infra/modules/s3-logging/main.tf
@@ -16,6 +16,7 @@ resource "aws_s3_bucket" "s3_encrypted_log" {
   # checkov:skip=CKV2_AWS_61:Lifecycle policy will be added in later ticket for post-pilot cleanup
   # checkov:skip=CKV2_AWS_62:Disable SNS requirement
   # checkov:skip=CKV_AWS_145:Access logging for s3 and elb does not support KMS SSE encryption
+  # checkov:skip=CKV_AWS_18:Unnecessary to recursively access log this access log
 }
 
 resource "aws_s3_bucket_versioning" "s3_encrypted_log" {

--- a/infra/modules/s3-logging/main.tf
+++ b/infra/modules/s3-logging/main.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "s3_encrypted_log"
       # using AES256. See:
       # - https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html
       # - https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
-      sse_algorithm     = "AES256"
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/infra/modules/s3-logging/outputs.tf
+++ b/infra/modules/s3-logging/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_id" {
+  value = aws_s3_bucket.s3_encrypted_log.id
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.s3_encrypted_log.name
+}

--- a/infra/modules/s3-logging/outputs.tf
+++ b/infra/modules/s3-logging/outputs.tf
@@ -1,7 +1,3 @@
 output "bucket_id" {
   value = aws_s3_bucket.s3_encrypted_log.id
 }
-
-output "bucket_name" {
-  value = aws_s3_bucket.s3_encrypted_log.name
-}

--- a/infra/modules/s3-logging/variables.tf
+++ b/infra/modules/s3-logging/variables.tf
@@ -1,0 +1,4 @@
+variable "logging_bucket_name" {
+  type        = string
+  description = "The name of the s3 bucket used for logging"
+}

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -65,7 +65,7 @@ resource "aws_lb" "alb" {
   # Enable access logging via s3 bucket
   access_logs {
     enabled = true
-    prefix  = "alb/${var.service_name}/"
+    prefix  = "alb/${var.service_name}"
     bucket  = var.s3_logging_bucket_id
   }
 }

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -66,7 +66,7 @@ resource "aws_lb" "alb" {
   access_logs {
     enabled = true
     prefix  = "alb/${var.service_name}/"
-    bucket  = var.s3_logging_bucket_name
+    bucket  = var.s3_logging_bucket_id
   }
 }
 

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -46,12 +46,6 @@ locals {
 ## - Protects the ALB with a WAF
 ############################################################################################
 
-module "alb_logging" {
-  source            = "../s3-encrypted"
-  s3_bucket_name    = var.service_name
-  log_target_prefix = var.service_name
-}
-
 resource "aws_lb" "alb" {
   name            = var.service_name
   idle_timeout    = "120"
@@ -71,8 +65,8 @@ resource "aws_lb" "alb" {
   # Enable access logging via s3 bucket
   access_logs {
     enabled = true
-    prefix  = var.service_name
-    bucket  = var.service_name
+    prefix  = "alb/${var.service_name}/"
+    bucket  = var.s3_logging_bucket_name
   }
 }
 

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -31,6 +31,11 @@ variable "ssl_cert_arn" {
   description = "The arn of the SSL certificate for the HTTPS ALB listener"
 }
 
+variable "s3_logging_bucket_name" {
+  type        = string
+  description = "The name of the s3 bucket for ALB access logging"
+}
+
 variable "waf_name" {
   type        = string
   description = "The name of the WAF used to protect the ALB"

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -31,9 +31,9 @@ variable "ssl_cert_arn" {
   description = "The arn of the SSL certificate for the HTTPS ALB listener"
 }
 
-variable "s3_logging_bucket_name" {
+variable "s3_logging_bucket_id" {
   type        = string
-  description = "The name of the s3 bucket for ALB access logging"
+  description = "The id of the s3 bucket for ALB access logging"
 }
 
 variable "waf_name" {


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-352

## Changes
> What was added, updated, or removed in this PR.

- Creates a separate terraform child module for making an s3 bucket for logging other AWS resources
- Creates one s3 bucket for logging to s3 for each environment, rather than one bucket for each resource in each environment
- Remove extra s3 bucket created for WAF logging because WAF is logging to cloudwatch

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

#103 added logging but the s3 bucket logging wasn't quite right. Corrected here.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

These changes have been deployed to `dev` and can be verified there.
